### PR TITLE
Use transcript support level to pre-filter transcripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   - add `squirls-bootstrap` to quickly bootstrap Squirls even without Spring
   - use transcript support level to filter transcripts
   - deprecate `Transcript.of(...)` static constructor, to be removed in the next version
+  - TODO - update docs regarding TSL
 
 ## ✈ v1.0.0
 - `squirls-cli`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - `Squirls`
   - add `squirls-bootstrap` to quickly bootstrap Squirls even without Spring
   - use transcript support level to filter transcripts
+  - allow excluding non-coding transcripts from the analysis
   - deprecate `Transcript.of(...)` static constructor, to be removed in the next version
   - TODO - update docs regarding TSL
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - `Squirls`
   - add `squirls-bootstrap` to quickly bootstrap Squirls even without Spring
+  - use transcript support level to filter transcripts
+  - deprecate `Transcript.of(...)` static constructor, to be removed in the next version
 
 ## ✈ v1.0.0
 - `squirls-cli`

--- a/squirls-bootstrap/src/main/java/org/monarchinitiative/squirls/bootstrap/SimpleDatasourceProperties.java
+++ b/squirls-bootstrap/src/main/java/org/monarchinitiative/squirls/bootstrap/SimpleDatasourceProperties.java
@@ -80,12 +80,13 @@ import org.monarchinitiative.squirls.initialize.DatasourceProperties;
 import java.util.Objects;
 
 /**
- * @since 1.0.1
  * @author Daniel Danis
+ * @since 1.0.1
  */
 public class SimpleDatasourceProperties implements DatasourceProperties {
 
     private int maxTranscriptSupportLevel = 5;
+    public boolean useNoncodingTranscripts = true;
 
     @Override
     public int maxTranscriptSupportLevel() {
@@ -99,22 +100,32 @@ public class SimpleDatasourceProperties implements DatasourceProperties {
     }
 
     @Override
+    public boolean useNoncodingTranscripts() {
+        return useNoncodingTranscripts;
+    }
+
+    public void setUseNoncodingTranscripts(boolean useNoncodingTranscripts) {
+        this.useNoncodingTranscripts = useNoncodingTranscripts;
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         SimpleDatasourceProperties that = (SimpleDatasourceProperties) o;
-        return maxTranscriptSupportLevel == that.maxTranscriptSupportLevel;
+        return useNoncodingTranscripts == that.useNoncodingTranscripts && maxTranscriptSupportLevel == that.maxTranscriptSupportLevel;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(maxTranscriptSupportLevel);
+        return Objects.hash(useNoncodingTranscripts, maxTranscriptSupportLevel);
     }
 
     @Override
     public String toString() {
         return "SimpleDatasourceProperties{" +
-                "maxTranscriptSupportLevel=" + maxTranscriptSupportLevel +
+                "useNoncodingTranscripts=" + useNoncodingTranscripts +
+                ", maxTranscriptSupportLevel=" + maxTranscriptSupportLevel +
                 '}';
     }
 }

--- a/squirls-bootstrap/src/main/java/org/monarchinitiative/squirls/bootstrap/SimpleDatasourceProperties.java
+++ b/squirls-bootstrap/src/main/java/org/monarchinitiative/squirls/bootstrap/SimpleDatasourceProperties.java
@@ -73,7 +73,9 @@
  *
  * Daniel Danis, Peter N Robinson, 2021
  */
-package org.monarchinitiative.squirls.core.reference;
+package org.monarchinitiative.squirls.bootstrap;
+
+import org.monarchinitiative.squirls.initialize.DatasourceProperties;
 
 import java.util.Objects;
 
@@ -81,48 +83,38 @@ import java.util.Objects;
  * @since 1.0.1
  * @author Daniel Danis
  */
-public class TranscriptModelServiceOptions {
+public class SimpleDatasourceProperties implements DatasourceProperties {
 
-    private static final TranscriptModelServiceOptions DEFAULT = of(5);
+    private int maxTranscriptSupportLevel = 5;
 
-    private final int maxTxSupportLevel;
-
-    private TranscriptModelServiceOptions(int maxTxSupportLevel) {
-        this.maxTxSupportLevel = maxTxSupportLevel;
+    @Override
+    public int maxTranscriptSupportLevel() {
+        return maxTranscriptSupportLevel;
     }
 
-    /**
-     * @return options that include transcripts supported by all transcript support levels.
-     */
-    public static TranscriptModelServiceOptions defaultOptions() {
-        return DEFAULT;
-    }
-
-    public static TranscriptModelServiceOptions of(int maxTxSupportLevel) {
-        return new TranscriptModelServiceOptions(maxTxSupportLevel);
-    }
-
-    public int maxTxSupportLevel() {
-        return maxTxSupportLevel;
+    public void setMaxTranscriptSupportLevel(int maxTranscriptSupportLevel) {
+        if (maxTranscriptSupportLevel > 5 || maxTranscriptSupportLevel <= 0)
+            throw new IllegalArgumentException("Max transcript support level must be in range [1,5] (was " + maxTranscriptSupportLevel + ")");
+        this.maxTranscriptSupportLevel = maxTranscriptSupportLevel;
     }
 
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        TranscriptModelServiceOptions that = (TranscriptModelServiceOptions) o;
-        return maxTxSupportLevel == that.maxTxSupportLevel;
+        SimpleDatasourceProperties that = (SimpleDatasourceProperties) o;
+        return maxTranscriptSupportLevel == that.maxTranscriptSupportLevel;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(maxTxSupportLevel);
+        return Objects.hash(maxTranscriptSupportLevel);
     }
 
     @Override
     public String toString() {
-        return "TranscriptModelServiceOptions{" +
-                "maxTxSupportLevel=" + maxTxSupportLevel +
+        return "SimpleDatasourceProperties{" +
+                "maxTranscriptSupportLevel=" + maxTranscriptSupportLevel +
                 '}';
     }
 }

--- a/squirls-bootstrap/src/main/java/org/monarchinitiative/squirls/bootstrap/SimpleSquirlsProperties.java
+++ b/squirls-bootstrap/src/main/java/org/monarchinitiative/squirls/bootstrap/SimpleSquirlsProperties.java
@@ -78,6 +78,7 @@ package org.monarchinitiative.squirls.bootstrap;
 
 import org.monarchinitiative.squirls.initialize.AnnotatorProperties;
 import org.monarchinitiative.squirls.initialize.ClassifierProperties;
+import org.monarchinitiative.squirls.initialize.DatasourceProperties;
 import org.monarchinitiative.squirls.initialize.SquirlsProperties;
 
 import java.io.File;
@@ -93,10 +94,13 @@ public class SimpleSquirlsProperties implements SquirlsProperties {
 
     private final AnnotatorProperties annotatorProperties;
 
+    private final DatasourceProperties datasourceProperties;
+
     private SimpleSquirlsProperties(Builder builder) {
         dataDirectory = builder.dataDirectory;
         classifierProperties = builder.classifierProperties;
         annotatorProperties = builder.annotatorProperties;
+        datasourceProperties = builder.datasourceProperties;
     }
 
     @Override
@@ -126,6 +130,11 @@ public class SimpleSquirlsProperties implements SquirlsProperties {
         return annotatorProperties;
     }
 
+    @Override
+    public DatasourceProperties getDatasource() {
+        return datasourceProperties;
+    }
+
     public static Builder builder(File dataDirectory) {
         return builder(dataDirectory.getAbsolutePath());
     }
@@ -142,6 +151,8 @@ public class SimpleSquirlsProperties implements SquirlsProperties {
 
         private AnnotatorProperties annotatorProperties = new SimpleAnnotatorProperties();
 
+        private DatasourceProperties datasourceProperties = new SimpleDatasourceProperties();
+
         private Builder(String dataDirectory) {
             this.dataDirectory = dataDirectory;
         }
@@ -153,6 +164,11 @@ public class SimpleSquirlsProperties implements SquirlsProperties {
 
         public Builder annotatorProperties(AnnotatorProperties annotatorProperties) {
             this.annotatorProperties = annotatorProperties;
+            return this;
+        }
+
+        public Builder datasourceProperties(DatasourceProperties datasourceProperties) {
+            this.datasourceProperties = datasourceProperties;
             return this;
         }
 

--- a/squirls-bootstrap/src/main/java/org/monarchinitiative/squirls/bootstrap/SquirlsConfigurationFactory.java
+++ b/squirls-bootstrap/src/main/java/org/monarchinitiative/squirls/bootstrap/SquirlsConfigurationFactory.java
@@ -222,9 +222,14 @@ public class SquirlsConfigurationFactory {
                 dataResolver.genomeFastaFaiPath(),
                 dataResolver.genomeFastaDictPath());
 
-        if (LOGGER.isInfoEnabled())
+        if (LOGGER.isInfoEnabled()) {
             LOGGER.info("Using transcripts with transcript support level <={}", datasourceProperties.maxTranscriptSupportLevel());
-        TranscriptModelServiceOptions transcriptModelServiceOptions = TranscriptModelServiceOptions.of(datasourceProperties.maxTranscriptSupportLevel());
+            if (datasourceProperties.useNoncodingTranscripts())
+                LOGGER.info("Including noncoding transcripts");
+            else
+                LOGGER.info("Excluding noncoding transcripts");
+        }
+        TranscriptModelServiceOptions transcriptModelServiceOptions = TranscriptModelServiceOptions.of(datasourceProperties.maxTranscriptSupportLevel(), datasourceProperties.useNoncodingTranscripts());
         TranscriptModelService transcriptModelService = TranscriptModelServiceDb.of(squirlsDatasource, strandedSequenceService.genomicAssembly(), transcriptModelServiceOptions);
 
         return new SquirlsDataServiceImpl(strandedSequenceService, transcriptModelService);

--- a/squirls-bootstrap/src/main/java/org/monarchinitiative/squirls/bootstrap/SquirlsConfigurationFactory.java
+++ b/squirls-bootstrap/src/main/java/org/monarchinitiative/squirls/bootstrap/SquirlsConfigurationFactory.java
@@ -218,7 +218,7 @@ public class SquirlsConfigurationFactory {
                 dataResolver.genomeFastaPath(),
                 dataResolver.genomeFastaFaiPath(),
                 dataResolver.genomeFastaDictPath());
-        TranscriptModelService transcriptModelService = new TranscriptModelServiceDb(squirlsDatasource, strandedSequenceService.genomicAssembly());
+        TranscriptModelService transcriptModelService = TranscriptModelServiceDb.of(squirlsDatasource, strandedSequenceService.genomicAssembly());
         return new SquirlsDataServiceImpl(strandedSequenceService, transcriptModelService);
     }
 

--- a/squirls-bootstrap/src/test/java/org/monarchinitiative/squirls/bootstrap/SquirlsFactoryTest.java
+++ b/squirls-bootstrap/src/test/java/org/monarchinitiative/squirls/bootstrap/SquirlsFactoryTest.java
@@ -94,6 +94,7 @@ public class SquirlsFactoryTest {
     private static final SimpleSquirlsProperties PROPERTIES = SimpleSquirlsProperties.builder(RESOURCES_PATH)
             .annotatorProperties(new SimpleAnnotatorProperties())
             .classifierProperties(new SimpleClassifierProperties())
+            .datasourceProperties(new SimpleDatasourceProperties())
             .build();
 
     @Test

--- a/squirls-cli/src/main/resources/application-template.yml
+++ b/squirls-cli/src/main/resources/application-template.yml
@@ -31,7 +31,10 @@ squirls:
   # Which splicing annotator to use
   #  version: agez
   #datasource:
-  #  Evaluate variant with respect to transcripts with transcript support level (TSL) below or equal to the value.
-  #  Lower TSL is higher support. The allowed range is [1,5], use 5 to disable transcript filtering.
+  #  # Evaluate variant with respect to transcripts with transcript support level (TSL) below or equal to the value.
+  #  # Lower TSL is higher support. The allowed range is [1,5], use 5 to disable transcript filtering.
   #  maxTranscriptSupportLevel: 5
+  #  # Evaluate variant with respect to all (coding and non-coding) transcripts.
+  #  # Choose from {true, false}
+  #  useNoncodingTranscripts: true
 

--- a/squirls-cli/src/main/resources/application-template.yml
+++ b/squirls-cli/src/main/resources/application-template.yml
@@ -30,4 +30,8 @@ squirls:
   #annotator:
   # Which splicing annotator to use
   #  version: agez
+  #datasource:
+  #  Evaluate variant with respect to transcripts with transcript support level (TSL) below or equal to the value.
+  #  Lower TSL is higher support. The allowed range is [1,5], use 5 to disable transcript filtering.
+  #  maxTranscriptSupportLevel: 5
 

--- a/squirls-cli/src/test/java/org/monarchinitiative/squirls/cli/data/Transcripts.java
+++ b/squirls-cli/src/test/java/org/monarchinitiative/squirls/cli/data/Transcripts.java
@@ -81,7 +81,6 @@ import org.monarchinitiative.svart.*;
 
 import java.util.List;
 
-// TODO - remove old transcript definitions
 class Transcripts {
 
     private Transcripts() {
@@ -196,34 +195,10 @@ class Transcripts {
      */
     private static TranscriptModel reduced_nf1_NM_000267_3(Contig contig) {
         return TranscriptModel.coding(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(),
-                29_421_944, 29_704_695, 29_421_944, 29_704_695, "NM_000267.3", "NF1",
+                29_421_944, 29_704_695, 29_421_944, 29_704_695, "NM_000267.3", "NF1", 1,
                 List.of(GenomicRegion.of(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(), 29_421_944, 29_422_387),
                         GenomicRegion.of(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(), 29_527_439, 29_527_613),
                         GenomicRegion.of(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(), 29_701_030, 29_704_695)));
-//        return SplicingTranscript.builder()
-//                .setAccessionId("NM_000267.3")
-//                .setCoordinates(new GenomeInterval(rd, Strand.FWD, 17, 29_421_945, 29_704_695, PositionType.ONE_BASED))
-//                // first
-//                .addExon(SplicingExon.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 17, 29_421_945, 29422387, PositionType.ONE_BASED))
-//                        .build())
-//                .addIntron(SplicingIntron.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 17, 29422387, 29_527_439))
-//                        .build())
-//                // 9th
-//                .addExon(SplicingExon.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 17, 29_527_440, 29_527_613, PositionType.ONE_BASED))
-//                        .build())
-//                .addIntron(SplicingIntron.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 17, 29_527_613, 29_701_030))
-//                        .build())
-//
-//                // last
-//                .addExon(SplicingExon.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 17, 29_701_031, 29_704_695, PositionType.ONE_BASED))
-//                        .build())
-//                .check(true)
-//                .build();
     }
 
     /**
@@ -233,67 +208,13 @@ class Transcripts {
      */
     private static TranscriptModel surf2_NM_017503_4(Contig contig) {
         return TranscriptModel.coding(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(),
-                136_223_424, 136_228_034, 136_223_424, 136_228_034, "NM_017503.4", "SURF2",
+                136_223_424, 136_228_034, 136_223_424, 136_228_034, "NM_017503.4", "SURF2", 1,
                 List.of(GenomicRegion.of(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(), 136_223_424, 136_223_546),
                         GenomicRegion.of(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(), 136_223_788, 136_223_944),
                         GenomicRegion.of(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(), 136_224_585, 136_224_690),
                         GenomicRegion.of(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(), 136_226_824, 136_227_005),
                         GenomicRegion.of(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(), 136_227_139, 136_227_310),
                         GenomicRegion.of(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(), 136_227_930, 136_228_034)));
-//        return SplicingTranscript.builder()
-//                .setAccessionId("NM_017503.4")
-//                .setCoordinates(new GenomeInterval(rd, Strand.FWD, 9, 136223425, 136228034))
-//                // 1
-//                .addExon(SplicingExon.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 9, 136223425, 136223546))
-//                        .build())
-//                .addIntron(SplicingIntron.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 9, 136223546, 136223789))
-//                        .setDonorScore(3.6156746223715936)
-//                        .setAcceptorScore(4.277366650982434)
-//                        .build())
-//                // 2
-//                .addExon(SplicingExon.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 9, 136223789, 136223944))
-//                        .build())
-//                .addIntron(SplicingIntron.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 9, 136223944, 136224586))
-//                        .setDonorScore(2.937332682375464)
-//                        .setAcceptorScore(10.499414519258275)
-//                        .build())
-//                // 3
-//                .addExon(SplicingExon.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 9, 136224586, 136224690))
-//                        .build())
-//                .addIntron(SplicingIntron.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 9, 136224690, 136226825))
-//                        .setDonorScore(9.136968204255682)
-//                        .setAcceptorScore(6.7796902152895875)
-//                        .build())
-//                // 4
-//                .addExon(SplicingExon.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 9, 136226825, 136227005))
-//                        .build())
-//                .addIntron(SplicingIntron.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 9, 136227005, 136227140))
-//                        .setDonorScore(6.3660441535158965)
-//                        .setAcceptorScore(8.610070990445257)
-//                        .build())
-//                // 5
-//                .addExon(SplicingExon.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 9, 136227140, 136227310))
-//                        .build())
-//                .addIntron(SplicingIntron.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 9, 136227310, 136227931))
-//                        .setDonorScore(10.25048397144629)
-//                        .setAcceptorScore(10.042811633569952)
-//                        .build())
-//                // 6
-//                .addExon(SplicingExon.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 9, 136227931, 136228034))
-//                        .build())
-//                .check(true)
-//                .build();
     }
 
     /**
@@ -309,67 +230,13 @@ class Transcripts {
     private static TranscriptModel surf2_NM_001278928_1(Contig contig) {
         // this is the same transcript as in the method surf2_NM_017503_4, except for the accession ID
         return TranscriptModel.coding(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(),
-                136_223_424, 136_228_034, 136_223_424, 136_228_034, "NM_001278928.1", "SURF2",
+                136_223_424, 136_228_034, 136_223_424, 136_228_034, "NM_001278928.1", "SURF2", 1,
                 List.of(GenomicRegion.of(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(), 136_223_424, 136_223_546),
                         GenomicRegion.of(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(), 136_223_788, 136_223_944),
                         GenomicRegion.of(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(), 136_224_585, 136_224_690),
                         GenomicRegion.of(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(), 136_226_824, 136_227_005),
                         GenomicRegion.of(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(), 136_227_139, 136_227_310),
                         GenomicRegion.of(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(), 136_227_930, 136_228_034)));
-//        return SplicingTranscript.builder()
-//                .setAccessionId("NM_001278928.1")
-//                .setCoordinates(new GenomeInterval(rd, Strand.FWD, 9, 136223425, 136228034))
-//                // 1
-//                .addExon(SplicingExon.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 9, 136223425, 136223546))
-//                        .build())
-//                .addIntron(SplicingIntron.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 9, 136223546, 136223789))
-//                        .setDonorScore(3.6156746223715936)
-//                        .setAcceptorScore(4.277366650982434)
-//                        .build())
-//                // 2
-//                .addExon(SplicingExon.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 9, 136223789, 136223944))
-//                        .build())
-//                .addIntron(SplicingIntron.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 9, 136223944, 136224586))
-//                        .setDonorScore(2.937332682375464)
-//                        .setAcceptorScore(10.499414519258275)
-//                        .build())
-//                // 3
-//                .addExon(SplicingExon.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 9, 136224586, 136224690))
-//                        .build())
-//                .addIntron(SplicingIntron.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 9, 136224690, 136226825))
-//                        .setDonorScore(9.136968204255682)
-//                        .setAcceptorScore(6.7796902152895875)
-//                        .build())
-//                // 4
-//                .addExon(SplicingExon.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 9, 136226825, 136227005))
-//                        .build())
-//                .addIntron(SplicingIntron.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 9, 136227005, 136227140))
-//                        .setDonorScore(6.3660441535158965)
-//                        .setAcceptorScore(8.610070990445257)
-//                        .build())
-//                // 5
-//                .addExon(SplicingExon.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 9, 136227140, 136227310))
-//                        .build())
-//                .addIntron(SplicingIntron.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 9, 136227310, 136227931))
-//                        .setDonorScore(10.25048397144629)
-//                        .setAcceptorScore(10.042811633569952)
-//                        .build())
-//                // 6
-//                .addExon(SplicingExon.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 9, 136227931, 136228034))
-//                        .build())
-//                .check(true)
-//                .build();
     }
 
     /**
@@ -379,7 +246,7 @@ class Transcripts {
      */
     private static TranscriptModel alpl_NM_000478_4(Contig contig) {
         return TranscriptModel.coding(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(),
-                21_835_915, 21_904_903, 21_835_915, 21_904_903, "NM_000478.4", "ALPL",
+                21_835_915, 21_904_903, 21_835_915, 21_904_903, "NM_000478.4", "ALPL", 1,
                 List.of(GenomicRegion.of(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(), 21_835_915, 21_836_010),
                         GenomicRegion.of(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(), 21_880_470, 21_880_635),
                         GenomicRegion.of(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(), 21_887_118, 21_887_238),
@@ -392,93 +259,6 @@ class Transcripts {
                         GenomicRegion.of(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(), 21_902_225, 21_902_417),
                         GenomicRegion.of(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(), 21_903_014, 21_903_134),
                         GenomicRegion.of(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(), 21_903_875, 21_904_903)));
-//        return SplicingTranscript.builder()
-//                .setAccessionId("NM_000478.4")
-//                .setCoordinates(new GenomeInterval(rd, Strand.FWD, 1, 21_835_916, 21_904_903, PositionType.ONE_BASED))
-//                // 1
-//                .addExon(SplicingExon.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 1, 21835916, 21836010, PositionType.ONE_BASED))
-//                        .build())
-//                .addIntron(SplicingIntron.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 1, 21836010, 21880470))
-//                        .build())
-//                // 2
-//                .addExon(SplicingExon.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 1, 21880471, 21880635, PositionType.ONE_BASED))
-//                        .build())
-//                .addIntron(SplicingIntron.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 1, 21880635, 21887118))
-//                        .build())
-//                // 3
-//                .addExon(SplicingExon.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 1, 21887119, 21887238, PositionType.ONE_BASED))
-//                        .build())
-//                .addIntron(SplicingIntron.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 1, 21887238, 21887589))
-//                        .build())
-//                // 4
-//                .addExon(SplicingExon.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 1, 21887590, 21887705, PositionType.ONE_BASED))
-//                        .build())
-//
-//                .addIntron(SplicingIntron.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 1, 21887705, 21889602))
-//                        .build())
-//                // 5
-//                .addExon(SplicingExon.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 1, 21_889_603, 21_889_777, PositionType.ONE_BASED))
-//                        .build())
-//                .addIntron(SplicingIntron.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 1, 21_889_777, 21_890_533))
-//                        .build())
-//                // 6
-//                .addExon(SplicingExon.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 1, 21_890_534, 21_890_709, PositionType.ONE_BASED))
-//                        .build())
-//                .addIntron(SplicingIntron.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 1, 21_890_709, 21_894_596))
-//                        .build())
-//                // 7
-//                .addExon(SplicingExon.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 1, 21_894_597, 21_894_740, PositionType.ONE_BASED))
-//                        .build())
-//                .addIntron(SplicingIntron.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 1, 21_894_740, 21_896_797))
-//                        .build())
-//                // 8
-//                .addExon(SplicingExon.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 1, 21896798, 21896867, PositionType.ONE_BASED))
-//                        .build())
-//                .addIntron(SplicingIntron.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 1, 21896867, 21900157))
-//                        .build())
-//                // 9
-//                .addExon(SplicingExon.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 1, 21900158, 21900292, PositionType.ONE_BASED))
-//                        .build())
-//                .addIntron(SplicingIntron.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 1, 21900292, 21902225))
-//                        .build())
-//                // 10
-//                .addExon(SplicingExon.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 1, 21902226, 21902417, PositionType.ONE_BASED))
-//                        .build())
-//                .addIntron(SplicingIntron.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 1, 21902417, 21903014))
-//                        .build())
-//                // 11
-//                .addExon(SplicingExon.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 1, 21903015, 21903134, PositionType.ONE_BASED))
-//                        .build())
-//                .addIntron(SplicingIntron.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 1, 21903134, 21903875))
-//                        .build())
-//                // 12
-//                .addExon(SplicingExon.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 1, 21903876, 21904903, PositionType.ONE_BASED))
-//                        .build())
-//                .check(true)
-//                .build();
     }
 
     /**
@@ -489,34 +269,10 @@ class Transcripts {
      */
     private static TranscriptModel reduced_tsc2_NM000548_3(Contig contig) {
         return TranscriptModel.coding(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(),
-                2_097_985, 2_139_492, 2_097_985, 2_139_492, "NM_000548.3", "TSC2",
+                2_097_985, 2_139_492, 2_097_985, 2_139_492, "NM_000548.3", "TSC2", 1,
                 List.of(GenomicRegion.of(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(), 2_097_985, 2_098_066),
                         GenomicRegion.of(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(), 2_110_670, 2_110_814),
                         GenomicRegion.of(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(), 2_138_446, 2_139_492)));
-//        return SplicingTranscript.builder()
-//                .setAccessionId("NM_000548.3")
-//                .setCoordinates(new GenomeInterval(rd, Strand.FWD, 16, 2_097_986, 2_139_492, PositionType.ONE_BASED))
-//                // first
-//                .addExon(SplicingExon.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 16, 2097986, 2098066, PositionType.ONE_BASED))
-//                        .build())
-//                .addIntron(SplicingIntron.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 16, 2_098_066, 2_110_670))
-//                        .build())
-//                // 11
-//                .addExon(SplicingExon.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 16, 2_110_671, 2_110_814, PositionType.ONE_BASED))
-//                        .build())
-//                .addIntron(SplicingIntron.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 16, 2_110_814, 2_138_446))
-//                        .build())
-//
-//                // last
-//                .addExon(SplicingExon.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 16, 2_138_447, 2_139_492, PositionType.ONE_BASED))
-//                        .build())
-//                .check(true)
-//                .build();
     }
 
     /**
@@ -527,34 +283,10 @@ class Transcripts {
      */
     private static TranscriptModel reduced_col4a5_NM_000495_4(Contig contig) {
         return TranscriptModel.coding(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(),
-                107_683_067, 107_940_775, 107_683_067, 107_940_775, "NM_000495.4", "COL4A5",
+                107_683_067, 107_940_775, 107_683_067, 107_940_775, "NM_000495.4", "COL4A5", 1,
                 List.of(GenomicRegion.of(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(), 107_683_067, 107_683_436),
                         GenomicRegion.of(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(), 107_849_971, 107_850_122),
                         GenomicRegion.of(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(), 107_939_526, 107_940_775)));
-//        return SplicingTranscript.builder()
-//                .setAccessionId("NM_000495.4")
-//                .setCoordinates(new GenomeInterval(rd, Strand.FWD, 23, 107_683_068, 107_940_775, PositionType.ONE_BASED))
-//                // first
-//                .addExon(SplicingExon.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 23, 107_683_068, 107_683_436, PositionType.ONE_BASED))
-//                        .build())
-//                .addIntron(SplicingIntron.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 23, 107_683_436, 107_849_971))
-//                        .build())
-//                // 29
-//                .addExon(SplicingExon.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 23, 107_849_972, 107_850_122, PositionType.ONE_BASED))
-//                        .build())
-//                .addIntron(SplicingIntron.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 23, 107_850_122, 107_939_526))
-//                        .build())
-//
-//                // last
-//                .addExon(SplicingExon.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 23, 107_939_527, 107_940_775, PositionType.ONE_BASED))
-//                        .build())
-//                .check(true)
-//                .build();
     }
 
     /**
@@ -565,34 +297,10 @@ class Transcripts {
      */
     private static TranscriptModel reduced_ryr1_NM_000540_2(Contig contig) {
         return TranscriptModel.coding(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(),
-                38_924_330, 39_078_204, 38_924_330, 39_078_204, "NM_000540.2", "RYR1",
+                38_924_330, 39_078_204, 38_924_330, 39_078_204, "NM_000540.2", "RYR1", 1,
                 List.of(GenomicRegion.of(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(), 38_924_330, 38_924_514),
                         GenomicRegion.of(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(), 39_075_582, 39_075_739),
                         GenomicRegion.of(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(), 39_077_964, 39_078_204)));
-//        return SplicingTranscript.builder()
-//                .setAccessionId("NM_000540.2")
-//                .setCoordinates(new GenomeInterval(rd, Strand.FWD, 19, 38_924_331, 39_078_204, PositionType.ONE_BASED))
-//                // first
-//                .addExon(SplicingExon.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 19, 38_924_331, 38_924_514, PositionType.ONE_BASED))
-//                        .build())
-//                .addIntron(SplicingIntron.builder() // this intron is not real. It spans all exons between the 1st and the 102th exon
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 19, 38_924_514, 39_075_582))
-//                        .build())
-//                // 102
-//                .addExon(SplicingExon.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 19, 39_075_583, 39_075_739, PositionType.ONE_BASED))
-//                        .build())
-//                .addIntron(SplicingIntron.builder() // this intron is not real. It spans all exons between the 102nd and the last exon
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 19, 39_075_739, 39_077_964))
-//                        .build())
-//
-//                // last (106th)
-//                .addExon(SplicingExon.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 19, 39_077_965, 39_078_204, PositionType.ONE_BASED))
-//                        .build())
-//                .check(true)
-//                .build();
     }
 
     /**
@@ -603,34 +311,10 @@ class Transcripts {
      */
     private static TranscriptModel hbb_NM_000518_4(Contig contig) {
         return TranscriptModel.coding(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(),
-                5_246_693, 5_248_301, 5_246_693, 5_248_301, "NM_000518.4", "HBB",
+                5_246_693, 5_248_301, 5_246_693, 5_248_301, "NM_000518.4", "HBB", 1,
                 List.of(GenomicRegion.of(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(), 5_246_693, 5_246_956),
                         GenomicRegion.of(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(), 5_247_806, 5_248_029),
                         GenomicRegion.of(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(), 5_248_159, 5_248_301))).withStrand(Strand.NEGATIVE);
-//        return SplicingTranscript.builder()
-//                .setAccessionId("NM_000518.4")
-//                .setCoordinates(new GenomeInterval(rd, Strand.FWD, 11, 5_246_694, 5_248_301, PositionType.ONE_BASED).withStrand(Strand.REV))
-//                // first
-//                .addExon(SplicingExon.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 11, 5_248_160, 5248301, PositionType.ONE_BASED).withStrand(Strand.REV))
-//                        .build())
-//                .addIntron(SplicingIntron.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 11, 5_248_029, 5_248_159).withStrand(Strand.REV).withStrand(Strand.REV))
-//                        .build())
-//                // second
-//                .addExon(SplicingExon.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 11, 5_247_807, 5_248_029, PositionType.ONE_BASED).withStrand(Strand.REV))
-//                        .build())
-//                .addIntron(SplicingIntron.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 11, 5_246_956, 5_247_806).withStrand(Strand.REV).withStrand(Strand.REV))
-//                        .build())
-//
-//                // last (third)
-//                .addExon(SplicingExon.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 11, 5_246_694, 5_246_956, PositionType.ONE_BASED).withStrand(Strand.REV))
-//                        .build())
-//                .check(true)
-//                .build();
     }
 
     /**
@@ -641,34 +325,10 @@ class Transcripts {
      */
     private static TranscriptModel reduced_brca2_NM_000059_3(Contig contig) {
         return TranscriptModel.coding(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(),
-                32_889_616, 32_973_809, 32_889_616, 32_973_809, "NM_000059.3", "BRCA2",
+                32_889_616, 32_973_809, 32_889_616, 32_973_809, "NM_000059.3", "BRCA2", 1,
                 List.of(GenomicRegion.of(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(), 32_889_616, 32_889_804),
                         GenomicRegion.of(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(), 32_930_564, 32_930_746),
                         GenomicRegion.of(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(), 32_972_298, 32_973_809)));
-//        return SplicingTranscript.builder()
-//                .setAccessionId("NM_000059.3")
-//                .setCoordinates(new GenomeInterval(rd, Strand.FWD, 13, 32_889_617, 32_973_809, PositionType.ONE_BASED))
-//                // first
-//                .addExon(SplicingExon.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 13, 32_889_617, 32_889_804, PositionType.ONE_BASED))
-//                        .build())
-//                .addIntron(SplicingIntron.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 13, 32_889_804, 32_930_564))
-//                        .build())
-//                // 15
-//                .addExon(SplicingExon.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 13, 32_930_565, 32_930_746, PositionType.ONE_BASED))
-//                        .build())
-//                .addIntron(SplicingIntron.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 13, 32_930_746, 32_972_298))
-//                        .build())
-//
-//                // last
-//                .addExon(SplicingExon.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 13, 32_972_299, 32_973_809, PositionType.ONE_BASED))
-//                        .build())
-//                .check(true)
-//                .build();
     }
 
 
@@ -680,34 +340,10 @@ class Transcripts {
      */
     private static TranscriptModel reduced_vwf_NM_000552_3(Contig contig) {
         return TranscriptModel.coding(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(),
-                6_058_039, 6_233_841, 6_058_039, 6_233_841, "NM_000552.3", "VWF",
+                6_058_039, 6_233_841, 6_058_039, 6_233_841, "NM_000552.3", "VWF", 1,
                 List.of(GenomicRegion.of(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(), 6_058_039, 6_058_369),
                         GenomicRegion.of(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(), 6_131_905, 6_132_064),
                         GenomicRegion.of(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(), 6_233_586, 6_233_841)))
                 .withStrand(Strand.NEGATIVE);
-//        return SplicingTranscript.builder()
-//                .setAccessionId("NM_000552.3")
-//                .setCoordinates(new GenomeInterval(rd, Strand.FWD, 12, 6_058_040, 6_233_841, PositionType.ONE_BASED).withStrand(Strand.REV))
-//                // first
-//                .addExon(SplicingExon.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 12, 6_233_587, 6_233_841, PositionType.ONE_BASED).withStrand(Strand.REV))
-//                        .build())
-//                .addIntron(SplicingIntron.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 12, 6_132_064, 6_233_586).withStrand(Strand.REV))
-//                        .build())
-//                // 26
-//                .addExon(SplicingExon.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 12, 6_131_906, 6_132_064, PositionType.ONE_BASED).withStrand(Strand.REV))
-//                        .build())
-//                .addIntron(SplicingIntron.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 12, 6_058_369, 6_131_905).withStrand(Strand.REV))
-//                        .build())
-//
-//                // last (52nd)
-//                .addExon(SplicingExon.builder()
-//                        .setInterval(new GenomeInterval(rd, Strand.FWD, 12, 6_058_040, 6_058_369, PositionType.ONE_BASED).withStrand(Strand.REV))
-//                        .build())
-//                .check(true)
-//                .build();
     }
 }

--- a/squirls-core/src/main/java/org/monarchinitiative/squirls/core/reference/TranscriptModel.java
+++ b/squirls-core/src/main/java/org/monarchinitiative/squirls/core/reference/TranscriptModel.java
@@ -96,6 +96,23 @@ public interface TranscriptModel extends GenomicRegion {
 
                                   String accessionId,
                                   String hgvsSymbol,
+                                  int transcriptSupportLevel,
+                                  List<GenomicRegion> exons) {
+        GenomicRegion cdsRegion = GenomicRegion.of(contig, strand, coordinateSystem, Position.of(cdsStart), Position.of(cdsEnd));
+        return TranscriptModelDefault.of(contig, strand, coordinateSystem, Position.of(start), Position.of(end), accessionId, hgvsSymbol, transcriptSupportLevel, true, cdsRegion, exons);
+    }
+
+    @Deprecated(forRemoval = true) // in >1.0.1
+    static TranscriptModel coding(Contig contig,
+                                  Strand strand,
+                                  CoordinateSystem coordinateSystem,
+                                  int start,
+                                  int end,
+                                  int cdsStart,
+                                  int cdsEnd,
+
+                                  String accessionId,
+                                  String hgvsSymbol,
                                   List<GenomicRegion> exons) {
         GenomicRegion cdsRegion = GenomicRegion.of(contig, strand, coordinateSystem, Position.of(cdsStart), Position.of(cdsEnd));
         return of(contig, strand, coordinateSystem, Position.of(start), Position.of(end), accessionId, hgvsSymbol, true, cdsRegion, exons);
@@ -108,10 +125,24 @@ public interface TranscriptModel extends GenomicRegion {
                                      int end,
                                      String accessionId,
                                      String hgvsSymbol,
+                                     int transcriptSupportLevel,
+                                     List<GenomicRegion> exons) {
+        return TranscriptModelDefault.of(contig, strand, coordinateSystem, Position.of(start), Position.of(end), accessionId, hgvsSymbol, transcriptSupportLevel, false, null, exons);
+    }
+
+    @Deprecated(forRemoval = true) // in >1.0.1
+    static TranscriptModel noncoding(Contig contig,
+                                     Strand strand,
+                                     CoordinateSystem coordinateSystem,
+                                     int start,
+                                     int end,
+                                     String accessionId,
+                                     String hgvsSymbol,
                                      List<GenomicRegion> exons) {
         return of(contig, strand, coordinateSystem, Position.of(start), Position.of(end), accessionId, hgvsSymbol, false, null, exons);
     }
 
+    @Deprecated(forRemoval = true) // in >1.0.1
     static TranscriptModel of(Contig contig,
                               Strand strand,
                               CoordinateSystem coordinateSystem,
@@ -123,7 +154,7 @@ public interface TranscriptModel extends GenomicRegion {
                               boolean isCoding,
                               GenomicRegion cdsRegion,
                               List<GenomicRegion> exons) {
-        return TranscriptModelDefault.of(contig, strand, coordinateSystem, start, end, accessionId, hgvsSymbol, isCoding, cdsRegion, exons);
+        return TranscriptModelDefault.of(contig, strand, coordinateSystem, start, end, accessionId, hgvsSymbol, 1, isCoding, cdsRegion, exons);
     }
 
     static List<GenomicRegion> computeIntronLocations(List<GenomicRegion> exons) {
@@ -172,6 +203,12 @@ public interface TranscriptModel extends GenomicRegion {
     TranscriptModel withCoordinateSystem(CoordinateSystem coordinateSystem);
 
     List<GenomicRegion> exons();
+
+    /**
+     * @return numeric transcript support level (TSL) where <code>1</code> indicates the highest TSL,
+     * <code>5</code> represents the lowest TSL, and <code>-1</code> means missing TSL.
+     */
+    int transcriptSupportLevel();
 
     default int exonCount() {
         return exons().size();

--- a/squirls-core/src/main/java/org/monarchinitiative/squirls/core/reference/TranscriptModelDefault.java
+++ b/squirls-core/src/main/java/org/monarchinitiative/squirls/core/reference/TranscriptModelDefault.java
@@ -88,6 +88,7 @@ import java.util.Objects;
 class TranscriptModelDefault extends BaseGenomicRegion<TranscriptModelDefault> implements TranscriptModel {
     private final String accessionId;
     private final String hgvsSymbol;
+    private final int transcriptSupportLevel;
     private final boolean isCoding;
     private final GenomicRegion cdsRegion;
     private final List<GenomicRegion> exons;
@@ -101,7 +102,7 @@ class TranscriptModelDefault extends BaseGenomicRegion<TranscriptModelDefault> i
 
                                    String accessionId,
                                    String hgvsSymbol,
-                                   boolean isCoding,
+                                   int transcriptSupportLevel, boolean isCoding,
                                    GenomicRegion cdsRegion,
                                    List<GenomicRegion> exons) {
         super(contig, strand, coordinateSystem, start, end);
@@ -110,6 +111,7 @@ class TranscriptModelDefault extends BaseGenomicRegion<TranscriptModelDefault> i
         this.hgvsSymbol = Objects.requireNonNull(hgvsSymbol, "HGVS symbol cannot be null");
         this.cdsRegion = cdsRegion;
         this.isCoding = isCoding;
+        this.transcriptSupportLevel = transcriptSupportLevel;
         if (exons == null) {
             throw new NullPointerException("Exons cannot be null");
         }
@@ -130,6 +132,7 @@ class TranscriptModelDefault extends BaseGenomicRegion<TranscriptModelDefault> i
 
                                      String accessionId,
                                      String hgvsSymbol,
+                                     int transcriptSupportLevel,
                                      boolean isCoding,
                                      GenomicRegion cdsRegion,
                                      List<GenomicRegion> exons) {
@@ -139,7 +142,7 @@ class TranscriptModelDefault extends BaseGenomicRegion<TranscriptModelDefault> i
             exonBuilder.add(exon.withCoordinateSystem(coordinateSystem));
         }
         GenomicRegion cdsOnCoordinateSystem = cdsRegion == null ? null : cdsRegion.withCoordinateSystem(coordinateSystem);
-        return new TranscriptModelDefault(contig, strand, coordinateSystem, start, end, accessionId, hgvsSymbol, isCoding, cdsOnCoordinateSystem, exonBuilder);
+        return new TranscriptModelDefault(contig, strand, coordinateSystem, start, end, accessionId, hgvsSymbol, transcriptSupportLevel, isCoding, cdsOnCoordinateSystem, exonBuilder);
     }
 
     @Override
@@ -171,6 +174,11 @@ class TranscriptModelDefault extends BaseGenomicRegion<TranscriptModelDefault> i
     }
 
     @Override
+    public int transcriptSupportLevel() {
+        return transcriptSupportLevel;
+    }
+
+    @Override
     public List<GenomicRegion> introns() {
         return introns;
     }
@@ -192,7 +200,7 @@ class TranscriptModelDefault extends BaseGenomicRegion<TranscriptModelDefault> i
             }
 
             return new TranscriptModelDefault(contig(), other, coordinateSystem(), start, end,
-                    accessionId, hgvsSymbol, isCoding, cdsRegionWithStrand, exonsWithStrand);
+                    accessionId, hgvsSymbol, transcriptSupportLevel, isCoding, cdsRegionWithStrand, exonsWithStrand);
         }
     }
 
@@ -209,7 +217,7 @@ class TranscriptModelDefault extends BaseGenomicRegion<TranscriptModelDefault> i
             }
 
             return new TranscriptModelDefault(contig(), strand(), other, startPositionWithCoordinateSystem(other), endPositionWithCoordinateSystem(other),
-                    accessionId, hgvsSymbol, isCoding, cdsWithCoordinateSystem, builder);
+                    accessionId, hgvsSymbol, transcriptSupportLevel, isCoding, cdsWithCoordinateSystem, builder);
         }
     }
 

--- a/squirls-core/src/main/java/org/monarchinitiative/squirls/core/reference/TranscriptModelServiceOptions.java
+++ b/squirls-core/src/main/java/org/monarchinitiative/squirls/core/reference/TranscriptModelServiceOptions.java
@@ -83,12 +83,15 @@ import java.util.Objects;
  */
 public class TranscriptModelServiceOptions {
 
-    private static final TranscriptModelServiceOptions DEFAULT = of(5);
+    private static final TranscriptModelServiceOptions DEFAULT = of(5, true);
 
     private final int maxTxSupportLevel;
 
-    private TranscriptModelServiceOptions(int maxTxSupportLevel) {
+    private final boolean useNoncodingTranscripts;
+
+    private TranscriptModelServiceOptions(int maxTxSupportLevel, boolean useNoncodingTranscripts) {
         this.maxTxSupportLevel = maxTxSupportLevel;
+        this.useNoncodingTranscripts = useNoncodingTranscripts;
     }
 
     /**
@@ -98,12 +101,16 @@ public class TranscriptModelServiceOptions {
         return DEFAULT;
     }
 
-    public static TranscriptModelServiceOptions of(int maxTxSupportLevel) {
-        return new TranscriptModelServiceOptions(maxTxSupportLevel);
+    public static TranscriptModelServiceOptions of(int maxTxSupportLevel, boolean useNoncodingTranscripts) {
+        return new TranscriptModelServiceOptions(maxTxSupportLevel, useNoncodingTranscripts);
     }
 
     public int maxTxSupportLevel() {
         return maxTxSupportLevel;
+    }
+
+    public boolean useNoncodingTranscripts() {
+        return useNoncodingTranscripts;
     }
 
     @Override
@@ -111,18 +118,19 @@ public class TranscriptModelServiceOptions {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         TranscriptModelServiceOptions that = (TranscriptModelServiceOptions) o;
-        return maxTxSupportLevel == that.maxTxSupportLevel;
+        return maxTxSupportLevel == that.maxTxSupportLevel && useNoncodingTranscripts == that.useNoncodingTranscripts;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(maxTxSupportLevel);
+        return Objects.hash(maxTxSupportLevel, useNoncodingTranscripts);
     }
 
     @Override
     public String toString() {
         return "TranscriptModelServiceOptions{" +
                 "maxTxSupportLevel=" + maxTxSupportLevel +
+                ", useNoncodingTranscripts=" + useNoncodingTranscripts +
                 '}';
     }
 }

--- a/squirls-core/src/main/java/org/monarchinitiative/squirls/core/reference/TranscriptModelServiceOptions.java
+++ b/squirls-core/src/main/java/org/monarchinitiative/squirls/core/reference/TranscriptModelServiceOptions.java
@@ -1,0 +1,49 @@
+package org.monarchinitiative.squirls.core.reference;
+
+import java.util.Objects;
+
+public class TranscriptModelServiceOptions {
+
+    private static final TranscriptModelServiceOptions DEFAULT = of(5);
+
+    private final int maxTxSupportLevel;
+
+    private TranscriptModelServiceOptions(int maxTxSupportLevel) {
+        this.maxTxSupportLevel = maxTxSupportLevel;
+    }
+
+    /**
+     * @return options that include transcripts supported by all transcript support levels.
+     */
+    public static TranscriptModelServiceOptions defaultOptions() {
+        return DEFAULT;
+    }
+
+    public static TranscriptModelServiceOptions of(int maxTxSupportLevel) {
+        return new TranscriptModelServiceOptions(maxTxSupportLevel);
+    }
+
+    public int maxTxSupportLevel() {
+        return maxTxSupportLevel;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TranscriptModelServiceOptions that = (TranscriptModelServiceOptions) o;
+        return maxTxSupportLevel == that.maxTxSupportLevel;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(maxTxSupportLevel);
+    }
+
+    @Override
+    public String toString() {
+        return "TranscriptModelServiceOptions{" +
+                "maxTxSupportLevel=" + maxTxSupportLevel +
+                '}';
+    }
+}

--- a/squirls-core/src/test/java/org/monarchinitiative/squirls/core/PojosForTesting.java
+++ b/squirls-core/src/test/java/org/monarchinitiative/squirls/core/PojosForTesting.java
@@ -138,7 +138,7 @@ public class PojosForTesting {
     public static TranscriptModel getTranscriptWithThreeExons(Contig contig) {
         return TranscriptModel.coding(
                 contig, Strand.POSITIVE, CoordinateSystem.zeroBased(), 1000, 2000, 1100, 1900,
-                "THREE_EXON", "HGVS_SYMBOL",
+                "THREE_EXON", "HGVS_SYMBOL", 1,
                 List.of(
                         GenomicRegion.of(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(), 1000, 1200),
                         GenomicRegion.of(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(), 1400, 1600),
@@ -149,14 +149,14 @@ public class PojosForTesting {
     public static TranscriptModel getTranscriptWithSingleExon(Contig contig) {
         return TranscriptModel.coding(
                 contig, Strand.POSITIVE, CoordinateSystem.zeroBased(), 1000, 2000, 1100, 1900,
-                "SINGLE_EXON", "HGVS_SYMBOL",
+                "SINGLE_EXON", "HGVS_SYMBOL", 1,
                 List.of(GenomicRegion.of(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(), 1000, 2000)));
     }
 
     public static TranscriptModel getTranscriptWithThreeExonsOnRevStrand(Contig contig) {
         return TranscriptModel.coding(
                 contig, Strand.NEGATIVE, CoordinateSystem.zeroBased(), 1000, 2000, 1100, 1900,
-                "THREE_EXON", "HGVS_SYMBOL",
+                "THREE_EXON", "HGVS_SYMBOL", 1,
                 List.of(
                         GenomicRegion.of(contig, Strand.NEGATIVE, CoordinateSystem.zeroBased(), 1000, 1200),
                         GenomicRegion.of(contig, Strand.NEGATIVE, CoordinateSystem.zeroBased(), 1400, 1600),
@@ -172,7 +172,7 @@ public class PojosForTesting {
      */
     public static TranscriptModel surf2_NM_017503_5(Contig contig) {
         return TranscriptModel.coding(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(),
-                136_223_425, 136_228_034, 136_223_425, 136_228_034, "NM_017503.5", "SURF2",
+                136_223_425, 136_228_034, 136_223_425, 136_228_034, "NM_017503.5", "SURF2", 1,
                 List.of(
                         GenomicRegion.of(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(), 136_223_425, 136_223_546),
                         GenomicRegion.of(contig, Strand.POSITIVE, CoordinateSystem.zeroBased(), 136_223_789, 136_223_944),

--- a/squirls-core/src/test/java/org/monarchinitiative/squirls/core/reference/TranscriptModelTest.java
+++ b/squirls-core/src/test/java/org/monarchinitiative/squirls/core/reference/TranscriptModelTest.java
@@ -93,7 +93,7 @@ public class TranscriptModelTest {
     @Test
     public void properties() {
         TranscriptModel tx = TranscriptModel.coding(CONTIG, Strand.POSITIVE, CoordinateSystem.zeroBased(), 100, 200,
-                110, 190, "NM_123456.3", "GENE",
+                110, 190, "NM_123456.3", "GENE", 1,
                 List.of(GenomicRegion.of(CONTIG, Strand.POSITIVE, CoordinateSystem.zeroBased(), Position.of(100), Position.of(130)),
                         GenomicRegion.of(CONTIG, Strand.POSITIVE, CoordinateSystem.zeroBased(), Position.of(150), Position.of(170)),
                         GenomicRegion.of(CONTIG, Strand.POSITIVE, CoordinateSystem.zeroBased(), Position.of(180), Position.of(200))));
@@ -119,7 +119,7 @@ public class TranscriptModelTest {
             "NEGATIVE, POSITIVE"})
     public void withStrand(Strand strand, Strand oppositeStrand) {
         TranscriptModel instance = TranscriptModel.coding(CONTIG, strand, CoordinateSystem.zeroBased(), 100, 200,
-                110, 190, "NM_123456.3", "GENE",
+                110, 190, "NM_123456.3", "GENE", 1,
                 List.of(GenomicRegion.of(CONTIG, strand, CoordinateSystem.zeroBased(), Position.of(100), Position.of(130)),
                         GenomicRegion.of(CONTIG, strand, CoordinateSystem.zeroBased(), Position.of(150), Position.of(170)),
                         GenomicRegion.of(CONTIG, strand, CoordinateSystem.zeroBased(), Position.of(180), Position.of(200))));
@@ -156,7 +156,7 @@ public class TranscriptModelTest {
             "NEGATIVE, POSITIVE"})
     public void withStrand_noncodingTx(Strand strand, Strand oppositeStrand) {
         TranscriptModel instance = TranscriptModel.noncoding(CONTIG, strand, CoordinateSystem.zeroBased(), 100, 200,
-                "NM_123456.3", "GENE",
+                "NM_123456.3", "GENE", 1,
                 List.of(GenomicRegion.of(CONTIG, strand, CoordinateSystem.zeroBased(), Position.of(100), Position.of(130)),
                         GenomicRegion.of(CONTIG, strand, CoordinateSystem.zeroBased(), Position.of(150), Position.of(170)),
                         GenomicRegion.of(CONTIG, strand, CoordinateSystem.zeroBased(), Position.of(180), Position.of(200))));
@@ -191,7 +191,7 @@ public class TranscriptModelTest {
     @Test
     public void withCoordinateSystem() {
         TranscriptModel instance = TranscriptModel.coding(CONTIG, Strand.POSITIVE, CoordinateSystem.zeroBased(), 100, 200,
-                110, 190, "NM_123456.3", "GENE",
+                110, 190, "NM_123456.3", "GENE", 1,
                 List.of(GenomicRegion.of(CONTIG, Strand.POSITIVE, CoordinateSystem.zeroBased(), Position.of(100), Position.of(130)),
                         GenomicRegion.of(CONTIG, Strand.POSITIVE, CoordinateSystem.zeroBased(), Position.of(150), Position.of(170)),
                         GenomicRegion.of(CONTIG, Strand.POSITIVE, CoordinateSystem.zeroBased(), Position.of(180), Position.of(200))));
@@ -218,7 +218,7 @@ public class TranscriptModelTest {
     @Test
     public void withCoordinateSystem_noncodingTx() {
         TranscriptModel instance = TranscriptModel.noncoding(CONTIG, Strand.POSITIVE, CoordinateSystem.zeroBased(), 100, 200,
-                "NM_123456.3", "GENE",
+                "NM_123456.3", "GENE", 1,
                 List.of(GenomicRegion.of(CONTIG, Strand.POSITIVE, CoordinateSystem.zeroBased(), Position.of(100), Position.of(130)),
                         GenomicRegion.of(CONTIG, Strand.POSITIVE, CoordinateSystem.zeroBased(), Position.of(150), Position.of(170)),
                         GenomicRegion.of(CONTIG, Strand.POSITIVE, CoordinateSystem.zeroBased(), Position.of(180), Position.of(200))));
@@ -246,7 +246,7 @@ public class TranscriptModelTest {
     @Test
     public void introns() {
         TranscriptModel instance = TranscriptModel.coding(CONTIG, Strand.POSITIVE, CoordinateSystem.zeroBased(), 100, 200,
-                110, 190, "NM_123456.3", "GENE",
+                110, 190, "NM_123456.3", "GENE", 1,
                 List.of(GenomicRegion.of(CONTIG, Strand.POSITIVE, CoordinateSystem.zeroBased(), Position.of(100), Position.of(130)),
                         GenomicRegion.of(CONTIG, Strand.POSITIVE, CoordinateSystem.zeroBased(), Position.of(150), Position.of(170)),
                         GenomicRegion.of(CONTIG, Strand.POSITIVE, CoordinateSystem.zeroBased(), Position.of(180), Position.of(200))));

--- a/squirls-ingest/src/main/java/org/monarchinitiative/squirls/ingest/IngestCommand.java
+++ b/squirls-ingest/src/main/java/org/monarchinitiative/squirls/ingest/IngestCommand.java
@@ -252,6 +252,7 @@ public class IngestCommand implements Callable<Integer> {
             LOGGER.error("Error: {}", e.getMessage());
             return 1;
         }
+        LOGGER.info("Done!");
         return 0;
     }
 }

--- a/squirls-ingest/src/main/java/org/monarchinitiative/squirls/ingest/SquirlsDataBuilder.java
+++ b/squirls-ingest/src/main/java/org/monarchinitiative/squirls/ingest/SquirlsDataBuilder.java
@@ -186,7 +186,7 @@ public class SquirlsDataBuilder {
     static void ingestTranscripts(DataSource dataSource,
                                   GenomicAssembly genomicAssembly,
                                   Collection<TranscriptModel> transcripts) throws SquirlsResourceException {
-        TranscriptModelServiceDb transcriptIngestDao = new TranscriptModelServiceDb(dataSource, genomicAssembly);
+        TranscriptModelServiceDb transcriptIngestDao = TranscriptModelServiceDb.of(dataSource, genomicAssembly);
         TranscriptsIngestRunner transcriptsIngestRunner = new TranscriptsIngestRunner(transcriptIngestDao, transcripts);
         transcriptsIngestRunner.run();
     }

--- a/squirls-ingest/src/main/java/org/monarchinitiative/squirls/ingest/transcripts/JannovarDataManager.java
+++ b/squirls-ingest/src/main/java/org/monarchinitiative/squirls/ingest/transcripts/JannovarDataManager.java
@@ -196,7 +196,7 @@ public class JannovarDataManager {
         that are marked as primary in UCSC, 7 for the longest transcript (in absence of both level and UCSC primary
         marking), and 8 for transcripts that fall neither into pseudo-level 6 and 7. A value of -1 is used for N/A.
         */
-        if (transcriptSupportLevel < -1 || transcriptSupportLevel > 8)
+        if (transcriptSupportLevel < -1 || transcriptSupportLevel == 0 || transcriptSupportLevel > 8)
             throw new IllegalArgumentException("Illegal TSL=" + transcriptSupportLevel);
 
         if (transcriptSupportLevel == 6) {

--- a/squirls-ingest/src/main/resources/db/migration/V1.0.1__add_transcript_support_level.sql
+++ b/squirls-ingest/src/main/resources/db/migration/V1.0.1__add_transcript_support_level.sql
@@ -1,0 +1,2 @@
+alter table SQUIRLS.TRANSCRIPTS
+    add TX_SUPPORT_LEVEL int; -- range from 1 to 5, where 1 is the most confident transcript

--- a/squirls-ingest/src/test/java/org/monarchinitiative/squirls/ingest/SquirlsDataBuilderTest.java
+++ b/squirls-ingest/src/test/java/org/monarchinitiative/squirls/ingest/SquirlsDataBuilderTest.java
@@ -128,7 +128,7 @@ public class SquirlsDataBuilderTest {
     private static List<TranscriptModel> makeTranscripts() {
         Contig chr2 = CONTIGS.get(1);
         TranscriptModel tx = TranscriptModel.coding(chr2, Strand.POSITIVE, CoordinateSystem.zeroBased(), 10_000, 20_000, 11_000, 19_000,
-                "adam", "ADAM",
+                "adam", "ADAM", 1,
                 List.of(GenomicRegion.of(chr2, Strand.POSITIVE, CoordinateSystem.zeroBased(), 10_000, 12_000),
                         GenomicRegion.of(chr2, Strand.POSITIVE, CoordinateSystem.zeroBased(), 14_000, 16_000),
                         GenomicRegion.of(chr2, Strand.POSITIVE, CoordinateSystem.zeroBased(), 18_000, 20_000)));

--- a/squirls-ingest/src/test/java/org/monarchinitiative/squirls/ingest/transcripts/JannovarDataManagerTest.java
+++ b/squirls-ingest/src/test/java/org/monarchinitiative/squirls/ingest/transcripts/JannovarDataManagerTest.java
@@ -76,19 +76,18 @@
 
 package org.monarchinitiative.squirls.ingest.transcripts;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.monarchinitiative.squirls.core.reference.TranscriptModel;
 import org.monarchinitiative.svart.GenomicAssembly;
 import org.monarchinitiative.svart.parsers.GenomicAssemblyParser;
 
-import java.io.BufferedWriter;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
@@ -108,5 +107,23 @@ public class JannovarDataManagerTest {
         assertThat(txsByGene.get("HNF4A"), hasSize(24));
         assertThat(txsByGene.get("GCK"), hasSize(14));
         assertThat(txsByGene.get("FBN1"), hasSize(11));
+
+        Map<String, TranscriptModel> fbn1Transcripts = txsByGene.get("FBN1").stream()
+                .collect(Collectors.toMap(TranscriptModel::accessionId, Function.identity()));
+
+        TranscriptModel tx = fbn1Transcripts.get("NM_000138.4");
+        assertThat(tx.hgvsSymbol(), equalTo("FBN1"));
+        assertThat(tx.accessionId(), equalTo("NM_000138.4"));
+        assertThat(tx.transcriptSupportLevel(), equalTo(-1));
+
+        tx = fbn1Transcripts.get("uc001zwx.2");
+        assertThat(tx.hgvsSymbol(), equalTo("FBN1"));
+        assertThat(tx.accessionId(), equalTo("uc001zwx.2"));
+        assertThat(tx.transcriptSupportLevel(), equalTo(1));
+
+        tx = fbn1Transcripts.get("ENST00000316623.5");
+        assertThat(tx.hgvsSymbol(), equalTo("FBN1"));
+        assertThat(tx.accessionId(), equalTo("ENST00000316623.5"));
+        assertThat(tx.transcriptSupportLevel(), equalTo(-1));
     }
 }

--- a/squirls-ingest/src/test/resources/org/monarchinitiative/squirls/ingest/create_schema.sql
+++ b/squirls-ingest/src/test/resources/org/monarchinitiative/squirls/ingest/create_schema.sql
@@ -102,6 +102,7 @@ create table SQUIRLS.TRANSCRIPTS
     STRAND       bool        not null, -- true if POSITIVE, false if NEGATIVE
     TX_ACCESSION char(50)    not null, -- transcript accession, e.g ENST00000123456.1_1, NM_000404.3
     HGVS_SYMBOL  varchar(50) not null,
+    TX_SUPPORT_LEVEL int,
     CDS_START    int,                  -- zero-based start coordinate of CDS start, null if noncoding transcript
     CDS_END      int                   -- one-based end coordinate of CDS end, null if noncoding transcript
 );

--- a/squirls-initialize/src/main/java/org/monarchinitiative/squirls/initialize/DatasourceProperties.java
+++ b/squirls-initialize/src/main/java/org/monarchinitiative/squirls/initialize/DatasourceProperties.java
@@ -73,56 +73,14 @@
  *
  * Daniel Danis, Peter N Robinson, 2021
  */
-package org.monarchinitiative.squirls.core.reference;
-
-import java.util.Objects;
+package org.monarchinitiative.squirls.initialize;
 
 /**
  * @since 1.0.1
  * @author Daniel Danis
  */
-public class TranscriptModelServiceOptions {
+public interface DatasourceProperties {
 
-    private static final TranscriptModelServiceOptions DEFAULT = of(5);
+    int maxTranscriptSupportLevel();
 
-    private final int maxTxSupportLevel;
-
-    private TranscriptModelServiceOptions(int maxTxSupportLevel) {
-        this.maxTxSupportLevel = maxTxSupportLevel;
-    }
-
-    /**
-     * @return options that include transcripts supported by all transcript support levels.
-     */
-    public static TranscriptModelServiceOptions defaultOptions() {
-        return DEFAULT;
-    }
-
-    public static TranscriptModelServiceOptions of(int maxTxSupportLevel) {
-        return new TranscriptModelServiceOptions(maxTxSupportLevel);
-    }
-
-    public int maxTxSupportLevel() {
-        return maxTxSupportLevel;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        TranscriptModelServiceOptions that = (TranscriptModelServiceOptions) o;
-        return maxTxSupportLevel == that.maxTxSupportLevel;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(maxTxSupportLevel);
-    }
-
-    @Override
-    public String toString() {
-        return "TranscriptModelServiceOptions{" +
-                "maxTxSupportLevel=" + maxTxSupportLevel +
-                '}';
-    }
 }

--- a/squirls-initialize/src/main/java/org/monarchinitiative/squirls/initialize/DatasourceProperties.java
+++ b/squirls-initialize/src/main/java/org/monarchinitiative/squirls/initialize/DatasourceProperties.java
@@ -83,4 +83,6 @@ public interface DatasourceProperties {
 
     int maxTranscriptSupportLevel();
 
+    boolean useNoncodingTranscripts();
+
 }

--- a/squirls-initialize/src/main/java/org/monarchinitiative/squirls/initialize/SquirlsProperties.java
+++ b/squirls-initialize/src/main/java/org/monarchinitiative/squirls/initialize/SquirlsProperties.java
@@ -78,6 +78,7 @@ package org.monarchinitiative.squirls.initialize;
 
 /**
  * @author Daniel Danis
+ * @since 1.0.0
  */
 public interface SquirlsProperties {
 
@@ -90,4 +91,6 @@ public interface SquirlsProperties {
     ClassifierProperties getClassifier();
 
     AnnotatorProperties getAnnotator();
+
+    DatasourceProperties getDatasource();
 }

--- a/squirls-io/src/main/java/org/monarchinitiative/squirls/io/classifier/Pipeline.java
+++ b/squirls-io/src/main/java/org/monarchinitiative/squirls/io/classifier/Pipeline.java
@@ -110,7 +110,7 @@ public class Pipeline<T extends SquirlsFeatures> extends AbstractBinaryClassifie
     @Override
     public Set<String> usedFeatureNames() {
         return Stream.concat(transformer.usedFeatureNames().stream(), classifier.usedFeatureNames().stream())
-                .collect(Collectors.toSet());
+                .collect(Collectors.toUnmodifiableSet());
     }
 
     @Override

--- a/squirls-io/src/main/java/org/monarchinitiative/squirls/io/classifier/v041/SquirlsClassifierDeserializerV041.java
+++ b/squirls-io/src/main/java/org/monarchinitiative/squirls/io/classifier/v041/SquirlsClassifierDeserializerV041.java
@@ -128,7 +128,7 @@ public class SquirlsClassifierDeserializerV041 implements SquirlsClassifierDeser
                 .classes(ptm.getRf().getClasses())
                 .addTrees(ptm.getRf().getTrees().values().stream()
                         .map(SquirlsClassifierDeserializerV041.<T>toDonorClassifierTree(ptm))
-                        .collect(Collectors.toList()))
+                        .collect(Collectors.toUnmodifiableList()))
                 .build();
     }
 
@@ -161,7 +161,7 @@ public class SquirlsClassifierDeserializerV041 implements SquirlsClassifierDeser
                 .classes(ptm.getRf().getClasses())
                 .addTrees(ptm.getRf().getTrees().values().stream()
                         .map(SquirlsClassifierDeserializerV041.<T>toAcceptorClassifierTree(ptm))
-                        .collect(Collectors.toList()))
+                        .collect(Collectors.toUnmodifiableList()))
                 .build();
     }
 

--- a/squirls-io/src/main/java/org/monarchinitiative/squirls/io/classifier/v041/SquirlsClassifierV041.java
+++ b/squirls-io/src/main/java/org/monarchinitiative/squirls/io/classifier/v041/SquirlsClassifierV041.java
@@ -149,8 +149,8 @@ class SquirlsClassifierV041 implements SquirlsClassifier {
             // flood the console
             if (MISSING_FEATURE_REPORTED.compareAndExchange(false, true)) {
                 Set<String> difference = usedFeatures.stream()
-                        .filter(fname -> !data.getFeatureNames()
-                                .contains(fname)).collect(Collectors.toSet());
+                        .filter(fname -> !data.getFeatureNames().contains(fname))
+                        .collect(Collectors.toUnmodifiableSet());
                 // report the error
                 String errorMsg = String.format("Missing one or more required features `[%s]`",
                         String.join(",", difference));

--- a/squirls-io/src/main/java/org/monarchinitiative/squirls/io/db/TranscriptModelBuilder.java
+++ b/squirls-io/src/main/java/org/monarchinitiative/squirls/io/db/TranscriptModelBuilder.java
@@ -102,6 +102,7 @@ class TranscriptModelBuilder {
     private int cdsEnd;
     private String accessionId = null;
     private String hgvsSymbol = null;
+    private int transcriptSupportLevel = -1;
 
     private TranscriptModelBuilder() {
     }
@@ -140,6 +141,11 @@ class TranscriptModelBuilder {
         return this;
     }
 
+    TranscriptModelBuilder transcriptSupportLevel(int transcriptSupportLevel) {
+        if (this.transcriptSupportLevel < 0) this.transcriptSupportLevel = transcriptSupportLevel;
+        return this;
+    }
+
     TranscriptModelBuilder setExon(int n, Strand strand, int start, int end) {
         exons.put(n, GenomicRegion.of(contig, strand, CoordinateSystem.zeroBased(), Position.of(start), Position.of(end)));
         return this;
@@ -161,21 +167,20 @@ class TranscriptModelBuilder {
         List<GenomicRegion> sorted = exons.keySet().stream().sorted().map(exons::get).collect(Collectors.toUnmodifiableList());
 
         return (isCoding)
-                ? TranscriptModel.coding(contig, strand, COORDINATE_SYSTEM, start, end, cdsStart, cdsEnd, accessionId, hgvsSymbol, sorted)
-                : TranscriptModel.noncoding(contig, strand, COORDINATE_SYSTEM, start, end, accessionId, hgvsSymbol, sorted);
+                ? TranscriptModel.coding(contig, strand, COORDINATE_SYSTEM, start, end, cdsStart, cdsEnd, accessionId, hgvsSymbol, transcriptSupportLevel, sorted)
+                : TranscriptModel.noncoding(contig, strand, COORDINATE_SYSTEM, start, end, accessionId, hgvsSymbol, transcriptSupportLevel, sorted);
     }
 
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        TranscriptModelBuilder builder = (TranscriptModelBuilder) o;
-        return start == builder.start && end == builder.end && cdsStart == builder.cdsStart && cdsEnd == builder.cdsEnd && Objects.equals(contig, builder.contig) && strand == builder.strand && Objects.equals(accessionId, builder.accessionId) && Objects.equals(hgvsSymbol, builder.hgvsSymbol) && Objects.equals(exons, builder.exons);
+        TranscriptModelBuilder that = (TranscriptModelBuilder) o;
+        return start == that.start && end == that.end && cdsStart == that.cdsStart && cdsEnd == that.cdsEnd && transcriptSupportLevel == that.transcriptSupportLevel && Objects.equals(exons, that.exons) && Objects.equals(contig, that.contig) && strand == that.strand && Objects.equals(accessionId, that.accessionId) && Objects.equals(hgvsSymbol, that.hgvsSymbol);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(contig, strand, start, end, cdsStart, cdsEnd, accessionId, hgvsSymbol, exons);
+        return Objects.hash(exons, contig, strand, start, end, cdsStart, cdsEnd, accessionId, hgvsSymbol, transcriptSupportLevel);
     }
-
 }

--- a/squirls-io/src/main/java/org/monarchinitiative/squirls/io/db/TranscriptModelServiceDb.java
+++ b/squirls-io/src/main/java/org/monarchinitiative/squirls/io/db/TranscriptModelServiceDb.java
@@ -338,7 +338,7 @@ public class TranscriptModelServiceDb implements TranscriptModelService {
     private List<TranscriptModel> processTranscriptResultSet(ResultSet rs) throws SQLException {
         Map<Integer, TranscriptModelBuilder> txMap = new HashMap<>();
         while (rs.next()) {
-            if (txSupportLevelIsAvailable && txAccessionIsNotEligible(rs.getInt("TX_SUPPORT_LEVEL")))
+            if (txSupportLevelIsAvailable && !transcriptIsEligible(rs.getInt("TX_SUPPORT_LEVEL")))
                 continue;
 
             int txId = rs.getInt(1);
@@ -367,9 +367,9 @@ public class TranscriptModelServiceDb implements TranscriptModelService {
                 .collect(Collectors.toUnmodifiableList());
     }
 
-    private boolean txAccessionIsNotEligible(int transcriptSupportLevel) {
-        return maxTxSupportLevel < transcriptSupportLevel
-                || transcriptSupportLevel < 0; // negative value means the transcript support level is N/A
+    private boolean transcriptIsEligible(int transcriptSupportLevel) {
+        // we use transcripts where TSL is missing (TSL = -1)
+        return transcriptSupportLevel <= maxTxSupportLevel;
     }
 
 }

--- a/squirls-io/src/test/java/org/monarchinitiative/squirls/io/db/TranscriptModelServiceDbTest.java
+++ b/squirls-io/src/test/java/org/monarchinitiative/squirls/io/db/TranscriptModelServiceDbTest.java
@@ -111,7 +111,7 @@ public class TranscriptModelServiceDbTest {
 
     @BeforeEach
     public void setUp() throws Exception {
-        instance = new TranscriptModelServiceDb(dataSource, genomicAssembly);
+        instance = TranscriptModelServiceDb.of(dataSource, genomicAssembly);
     }
 
     @Test

--- a/squirls-io/src/test/resources/org/monarchinitiative/squirls/io/db/transcripts_create_tables.sql
+++ b/squirls-io/src/test/resources/org/monarchinitiative/squirls/io/db/transcripts_create_tables.sql
@@ -79,18 +79,19 @@ create schema if not exists SQUIRLS;
 drop table if exists SQUIRLS.TRANSCRIPTS;
 create table SQUIRLS.TRANSCRIPTS
 (
-    TX_ID        int         not null auto_increment,
+    TX_ID            int         not null auto_increment,
 
-    CONTIG       int         not null, -- contig id which maps to `SPLICING.CONTIG.CONTIG_ID`
-    BEGIN        int         not null, -- 0-based (exclusive) begin position of the region
-    END          int         not null, -- 0-based (inclusive) end position of the region
-    BEGIN_ON_POS int         not null, -- 0-based (exclusive) begin position of the region on FWD strand
-    END_ON_POS   int         not null, -- 0-based (inclusive) end position of the region on FWD strand
-    STRAND       bool        not null, -- true if POSITIVE, false if NEGATIVE
-    TX_ACCESSION char(50)    not null, -- transcript accession, e.g ENST00000123456.1_1, NM_000404.3
-    HGVS_SYMBOL  varchar(50) not null,
-    CDS_START    int,                  -- zero-based start coordinate of CDS start, null if noncoding transcript
-    CDS_END      int                   -- one-based end coordinate of CDS end, null if noncoding transcript
+    CONTIG           int         not null, -- contig id which maps to `SPLICING.CONTIG.CONTIG_ID`
+    BEGIN            int         not null, -- 0-based (exclusive) begin position of the region
+    END              int         not null, -- 0-based (inclusive) end position of the region
+    BEGIN_ON_POS     int         not null, -- 0-based (exclusive) begin position of the region on FWD strand
+    END_ON_POS       int         not null, -- 0-based (inclusive) end position of the region on FWD strand
+    STRAND           bool        not null, -- true if POSITIVE, false if NEGATIVE
+    TX_ACCESSION     char(50)    not null, -- transcript accession, e.g ENST00000123456.1_1, NM_000404.3
+    HGVS_SYMBOL      varchar(50) not null,
+    CDS_START        int,                  -- zero-based start coordinate of CDS start, null if noncoding transcript
+    CDS_END          int,                  -- one-based end coordinate of CDS end, null if noncoding transcript
+    TX_SUPPORT_LEVEL int                   -- range from 1 to 5, where 1 is the most confident transcript
 );
 
 create index TRANSCRIPTS__ASSEMBLY_ID_CONTIG_START_ON_POS_END_ON_POS_index

--- a/squirls-io/src/test/resources/org/monarchinitiative/squirls/io/db/transcripts_insert.sql
+++ b/squirls-io/src/test/resources/org/monarchinitiative/squirls/io/db/transcripts_insert.sql
@@ -1,10 +1,10 @@
 insert into SQUIRLS.TRANSCRIPTS(TX_ID, CONTIG, BEGIN, END, BEGIN_ON_POS, END_ON_POS, STRAND,
-                                TX_ACCESSION, HGVS_SYMBOL, CDS_START, CDS_END)
-values (1, 1, 100, 900, 100, 900, true, 'NM_000001.1', 'JOE', 200, 800),
-       (2, 1, 8500, 9500, 500, 1500, false, 'NM_000002.1', 'JAMIE', 8600, 9400),
-       (3, 1, 1100, 1900, 1100, 1900, true, 'NM_000003.1', 'JIM', 1200, 1800),
-       (4, 2, 100, 900, 100, 900, true, 'NM_000004.1', 'JOHNNY', 200, 800),
-       (5, 2, 1000, 2000, 1000, 2000, true, 'NM_000005.1', 'JESSE', null, null);
+                                TX_ACCESSION, HGVS_SYMBOL, CDS_START, CDS_END, TX_SUPPORT_LEVEL)
+values (1, 1, 100, 900, 100, 900, true, 'NM_000001.1', 'JOE', 200, 800, 1),
+       (2, 1, 8500, 9500, 500, 1500, false, 'NM_000002.1', 'JAMIE', 8600, 9400, 1),
+       (3, 1, 1100, 1900, 1100, 1900, true, 'NM_000003.1', 'JIM', 1200, 1800, 1),
+       (4, 2, 100, 900, 100, 900, true, 'NM_000004.1', 'JOHNNY', 200, 800, 1),
+       (5, 2, 1000, 2000, 1000, 2000, true, 'NM_000005.1', 'JESSE', null, null, 1);
 
 insert into SQUIRLS.EXONS(TX_ID, BEGIN, END, EXON_NUMBER)
 values (1, 100, 300, 0),

--- a/squirls-spring-boot-autoconfigure/src/main/java/org/monarchinitiative/squirls/autoconfigure/DatasourcePropertiesImpl.java
+++ b/squirls-spring-boot-autoconfigure/src/main/java/org/monarchinitiative/squirls/autoconfigure/DatasourcePropertiesImpl.java
@@ -73,56 +73,28 @@
  *
  * Daniel Danis, Peter N Robinson, 2021
  */
-package org.monarchinitiative.squirls.core.reference;
+package org.monarchinitiative.squirls.autoconfigure;
 
-import java.util.Objects;
+import org.monarchinitiative.squirls.initialize.DatasourceProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
- * @since 1.0.1
  * @author Daniel Danis
+ * @since 1.0.1
  */
-public class TranscriptModelServiceOptions {
+@ConfigurationProperties(prefix = "squirls.datasource")
+public class DatasourcePropertiesImpl implements DatasourceProperties {
 
-    private static final TranscriptModelServiceOptions DEFAULT = of(5);
-
-    private final int maxTxSupportLevel;
-
-    private TranscriptModelServiceOptions(int maxTxSupportLevel) {
-        this.maxTxSupportLevel = maxTxSupportLevel;
-    }
-
-    /**
-     * @return options that include transcripts supported by all transcript support levels.
-     */
-    public static TranscriptModelServiceOptions defaultOptions() {
-        return DEFAULT;
-    }
-
-    public static TranscriptModelServiceOptions of(int maxTxSupportLevel) {
-        return new TranscriptModelServiceOptions(maxTxSupportLevel);
-    }
-
-    public int maxTxSupportLevel() {
-        return maxTxSupportLevel;
-    }
+    private int maxTranscriptSupportLevel = 5;
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        TranscriptModelServiceOptions that = (TranscriptModelServiceOptions) o;
-        return maxTxSupportLevel == that.maxTxSupportLevel;
+    public int maxTranscriptSupportLevel() {
+        return maxTranscriptSupportLevel;
     }
 
-    @Override
-    public int hashCode() {
-        return Objects.hash(maxTxSupportLevel);
-    }
-
-    @Override
-    public String toString() {
-        return "TranscriptModelServiceOptions{" +
-                "maxTxSupportLevel=" + maxTxSupportLevel +
-                '}';
+    public void setMaxTranscriptSupportLevel(int maxTranscriptSupportLevel) {
+        if (maxTranscriptSupportLevel > 5 || maxTranscriptSupportLevel <= 0)
+            throw new IllegalArgumentException("Max transcript support level must be in range [1,5] (was " + maxTranscriptSupportLevel + ")");
+        this.maxTranscriptSupportLevel = maxTranscriptSupportLevel;
     }
 }

--- a/squirls-spring-boot-autoconfigure/src/main/java/org/monarchinitiative/squirls/autoconfigure/DatasourcePropertiesImpl.java
+++ b/squirls-spring-boot-autoconfigure/src/main/java/org/monarchinitiative/squirls/autoconfigure/DatasourcePropertiesImpl.java
@@ -78,6 +78,8 @@ package org.monarchinitiative.squirls.autoconfigure;
 import org.monarchinitiative.squirls.initialize.DatasourceProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.util.Objects;
+
 /**
  * @author Daniel Danis
  * @since 1.0.1
@@ -86,6 +88,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class DatasourcePropertiesImpl implements DatasourceProperties {
 
     private int maxTranscriptSupportLevel = 5;
+
+    private boolean useNoncodingTranscripts = true;
 
     @Override
     public int maxTranscriptSupportLevel() {
@@ -96,5 +100,35 @@ public class DatasourcePropertiesImpl implements DatasourceProperties {
         if (maxTranscriptSupportLevel > 5 || maxTranscriptSupportLevel <= 0)
             throw new IllegalArgumentException("Max transcript support level must be in range [1,5] (was " + maxTranscriptSupportLevel + ")");
         this.maxTranscriptSupportLevel = maxTranscriptSupportLevel;
+    }
+
+    @Override
+    public boolean useNoncodingTranscripts() {
+        return useNoncodingTranscripts;
+    }
+
+    public void setUseNoncodingTranscripts(boolean useNoncodingTranscripts) {
+        this.useNoncodingTranscripts = useNoncodingTranscripts;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DatasourcePropertiesImpl that = (DatasourcePropertiesImpl) o;
+        return maxTranscriptSupportLevel == that.maxTranscriptSupportLevel && useNoncodingTranscripts == that.useNoncodingTranscripts;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(maxTranscriptSupportLevel, useNoncodingTranscripts);
+    }
+
+    @Override
+    public String toString() {
+        return "DatasourcePropertiesImpl{" +
+                "maxTranscriptSupportLevel=" + maxTranscriptSupportLevel +
+                ", useNoncodingTranscripts=" + useNoncodingTranscripts +
+                '}';
     }
 }

--- a/squirls-spring-boot-autoconfigure/src/main/java/org/monarchinitiative/squirls/autoconfigure/SquirlsAutoConfiguration.java
+++ b/squirls-spring-boot-autoconfigure/src/main/java/org/monarchinitiative/squirls/autoconfigure/SquirlsAutoConfiguration.java
@@ -217,7 +217,7 @@ public class SquirlsAutoConfiguration {
 
     @Bean
     public TranscriptModelService transcriptModelService(DataSource squirlsDatasource, GenomicAssembly genomicAssembly) throws SquirlsResourceException {
-        return new TranscriptModelServiceDb(squirlsDatasource, genomicAssembly);
+        return TranscriptModelServiceDb.of(squirlsDatasource, genomicAssembly);
     }
 
     @Bean

--- a/squirls-spring-boot-autoconfigure/src/main/java/org/monarchinitiative/squirls/autoconfigure/SquirlsAutoConfiguration.java
+++ b/squirls-spring-boot-autoconfigure/src/main/java/org/monarchinitiative/squirls/autoconfigure/SquirlsAutoConfiguration.java
@@ -226,10 +226,15 @@ public class SquirlsAutoConfiguration {
 
     @Bean
     public TranscriptModelServiceOptions transcriptModelServiceOptions(SquirlsProperties properties) {
-        int maxTxSupportLevel = properties.getDatasource().maxTranscriptSupportLevel();
-        if (LOGGER.isInfoEnabled())
-            LOGGER.info("Using transcripts with transcript support level <={}", maxTxSupportLevel);
-        return TranscriptModelServiceOptions.of(maxTxSupportLevel);
+        DatasourceProperties datasourceProperties = properties.getDatasource();
+        if (LOGGER.isInfoEnabled()) {
+            LOGGER.info("Using transcripts with transcript support level <={}", datasourceProperties.maxTranscriptSupportLevel());
+            if (datasourceProperties.useNoncodingTranscripts())
+                LOGGER.info("Including noncoding transcripts");
+            else
+                LOGGER.info("Excluding noncoding transcripts");
+        }
+        return TranscriptModelServiceOptions.of(datasourceProperties.maxTranscriptSupportLevel(), datasourceProperties.useNoncodingTranscripts());
     }
 
     @Bean

--- a/squirls-spring-boot-autoconfigure/src/main/java/org/monarchinitiative/squirls/autoconfigure/SquirlsAutoConfiguration.java
+++ b/squirls-spring-boot-autoconfigure/src/main/java/org/monarchinitiative/squirls/autoconfigure/SquirlsAutoConfiguration.java
@@ -86,6 +86,7 @@ import org.monarchinitiative.squirls.core.classifier.SquirlsClassifier;
 import org.monarchinitiative.squirls.core.reference.SplicingPwmData;
 import org.monarchinitiative.squirls.core.reference.StrandedSequenceService;
 import org.monarchinitiative.squirls.core.reference.TranscriptModelService;
+import org.monarchinitiative.squirls.core.reference.TranscriptModelServiceOptions;
 import org.monarchinitiative.squirls.core.scoring.AGEZSplicingAnnotator;
 import org.monarchinitiative.squirls.core.scoring.DenseSplicingAnnotator;
 import org.monarchinitiative.squirls.core.scoring.SplicingAnnotator;
@@ -142,7 +143,8 @@ import java.util.stream.Collectors;
 @EnableConfigurationProperties({
         SquirlsPropertiesImpl.class,
         ClassifierPropertiesImpl.class,
-        AnnotatorPropertiesImpl.class})
+        AnnotatorPropertiesImpl.class,
+        DatasourcePropertiesImpl.class})
 public class SquirlsAutoConfiguration {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SquirlsAutoConfiguration.class);
@@ -216,8 +218,18 @@ public class SquirlsAutoConfiguration {
     }
 
     @Bean
-    public TranscriptModelService transcriptModelService(DataSource squirlsDatasource, GenomicAssembly genomicAssembly) throws SquirlsResourceException {
-        return TranscriptModelServiceDb.of(squirlsDatasource, genomicAssembly);
+    public TranscriptModelService transcriptModelService(DataSource squirlsDatasource,
+                                                         GenomicAssembly genomicAssembly,
+                                                         TranscriptModelServiceOptions transcriptModelServiceOptions) throws SquirlsResourceException {
+        return TranscriptModelServiceDb.of(squirlsDatasource, genomicAssembly, transcriptModelServiceOptions);
+    }
+
+    @Bean
+    public TranscriptModelServiceOptions transcriptModelServiceOptions(SquirlsProperties properties) {
+        int maxTxSupportLevel = properties.getDatasource().maxTranscriptSupportLevel();
+        if (LOGGER.isInfoEnabled())
+            LOGGER.info("Using transcripts with transcript support level <={}", maxTxSupportLevel);
+        return TranscriptModelServiceOptions.of(maxTxSupportLevel);
     }
 
     @Bean

--- a/squirls-spring-boot-autoconfigure/src/main/java/org/monarchinitiative/squirls/autoconfigure/SquirlsPropertiesImpl.java
+++ b/squirls-spring-boot-autoconfigure/src/main/java/org/monarchinitiative/squirls/autoconfigure/SquirlsPropertiesImpl.java
@@ -78,6 +78,7 @@ package org.monarchinitiative.squirls.autoconfigure;
 
 import org.monarchinitiative.squirls.initialize.AnnotatorProperties;
 import org.monarchinitiative.squirls.initialize.ClassifierProperties;
+import org.monarchinitiative.squirls.initialize.DatasourceProperties;
 import org.monarchinitiative.squirls.initialize.SquirlsProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
@@ -111,6 +112,9 @@ public class SquirlsPropertiesImpl implements SquirlsProperties {
 
     @NestedConfigurationProperty // squirls.annotator
     private AnnotatorProperties annotator = new AnnotatorPropertiesImpl();
+
+    @NestedConfigurationProperty // squirls.datasource
+    private DatasourceProperties datasource = new DatasourcePropertiesImpl();
 
     @Override
     public String getDataDirectory() {
@@ -151,6 +155,15 @@ public class SquirlsPropertiesImpl implements SquirlsProperties {
     @Override
     public AnnotatorProperties getAnnotator() {
         return annotator;
+    }
+
+    public void setDatasource(DatasourceProperties datasource) {
+        this.datasource = datasource;
+    }
+
+    @Override
+    public DatasourceProperties getDatasource() {
+        return datasource;
     }
 
     public void setAnnotator(AnnotatorProperties annotator) {

--- a/squirls-spring-boot-autoconfigure/src/test/java/org/monarchinitiative/squirls/autoconfigure/SquirlsAutoConfigurationTest.java
+++ b/squirls-spring-boot-autoconfigure/src/test/java/org/monarchinitiative/squirls/autoconfigure/SquirlsAutoConfigurationTest.java
@@ -120,6 +120,7 @@ class SquirlsAutoConfigurationTest extends AbstractAutoConfigurationTest {
          */
         SquirlsProperties properties = context.getBean(SquirlsProperties.class);
         assertThat(properties.getClassifier().getVersion(), is("v0.4.6"));
+        assertThat(properties.getDatasource().maxTranscriptSupportLevel(), is(5));
 
         /*
          * High-level beans


### PR DESCRIPTION
- use *transcript support level* to pre-filter transcripts
- allow excluding non-coding transcripts from the analysis
- deprecate `Transcript.of(...)` static constructor