### PR TITLE
Unclear instruction about output file

### DIFF
--- a/docs/running.rst
+++ b/docs/running.rst
@@ -71,9 +71,9 @@ To annotate more than just a few variant positions, it may be more convenient to
 Let's run the ``annotate-csv`` command to annotate four variants stored in the `example.csv`_ file
 (an example CSV file with 4 variants stored in Squirls repository)::
 
-  java -jar squirls-cli.jar annotate-csv -d $SQUIRLS_DATA example.csv output
+  java -jar squirls-cli.jar annotate-csv -d $SQUIRLS_DATA example.csv path/to/output/file
 
-Squirls reads the variants and stores the scores into ``output.html`` file. The *HTML* is the default output format,
+Squirls reads the variants and stores the scores into ``path/to/output/file.html`` file. The *HTML* is the default output format,
 see :ref:`rstoutputformats` section for more details.
 
 Mandatory arguments
@@ -109,9 +109,9 @@ The aim of this command is to annotate variants in a VCF file and to store the r
 
 To annotate variants in the `example.vcf`_ file (an example VCF file with 6 variants stored in Squirls repository), run::
 
-  $ java -jar squirls-cli.jar annotate-vcf -d $SQUIRLS_DATA example.vcf output
+  $ java -jar squirls-cli.jar annotate-vcf -d $SQUIRLS_DATA example.vcf path/to/output/file
 
-After the annotation, the results are stored at ``output.html``.
+After the annotation, the results are stored at ``path/to/output/file.html``.
 
 Mandatory arguments
 ~~~~~~~~~~~~~~~~~~~

--- a/squirls-cli/src/main/java/org/monarchinitiative/squirls/cli/cmd/AnnotatingSquirlsCommand.java
+++ b/squirls-cli/src/main/java/org/monarchinitiative/squirls/cli/cmd/AnnotatingSquirlsCommand.java
@@ -79,6 +79,9 @@ package org.monarchinitiative.squirls.cli.cmd;
 import org.monarchinitiative.squirls.cli.writers.*;
 import picocli.CommandLine;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.*;
 
 /**
@@ -130,7 +133,16 @@ public abstract class AnnotatingSquirlsCommand extends SquirlsCommand {
         return formats;
     }
 
-    protected OutputOptions prepareOutputOptions(String outputPrefix) {
+    protected OutputOptions prepareOutputOptions(Path outputPrefix) throws IOException {
+        // Ensure the parent folders exist or explode.
+        if (Files.isDirectory(outputPrefix)) {
+            LOGGER.warn("Provided output prefix points to an existing directory. Results will be stored at {}/squirls*", outputPrefix.toAbsolutePath());
+            outputPrefix = outputPrefix.resolve("squirls");
+        }
+        Path parent = outputPrefix.getParent();
+        if (!Files.isDirectory(parent))
+            Files.createDirectories(parent);
+
         return OutputOptions.builder()
                 .setOutputPrefix(outputPrefix)
                 .addOutputFormats(parseOutputFormats(outputFormats))

--- a/squirls-cli/src/main/java/org/monarchinitiative/squirls/cli/cmd/annotate_csv/AnnotateCsvCommand.java
+++ b/squirls-cli/src/main/java/org/monarchinitiative/squirls/cli/cmd/annotate_csv/AnnotateCsvCommand.java
@@ -135,9 +135,9 @@ public class AnnotateCsvCommand extends AnnotatingSquirlsCommand {
     public Path inputPath;
 
     @CommandLine.Parameters(index = "1",
-            paramLabel = "path/to/output",
+            paramLabel = "output",
             description = "Prefix for the output files")
-    public String outputPrefix;
+    public Path outputPrefix = Path.of("output");
 
     private static GenomicVariant parseCsvRecord(GenomicAssembly assembly, CSVRecord record) throws SquirlsException {
         // parse contig

--- a/squirls-cli/src/main/java/org/monarchinitiative/squirls/cli/cmd/annotate_vcf/AnnotateVcfCommand.java
+++ b/squirls-cli/src/main/java/org/monarchinitiative/squirls/cli/cmd/annotate_vcf/AnnotateVcfCommand.java
@@ -130,13 +130,13 @@ public class AnnotateVcfCommand extends AnnotatingSquirlsCommand {
 
     @CommandLine.Parameters(index = "0",
             paramLabel = "input.vcf",
-            description = "Path to the input VCF file")
+            description = "Path to the input VCF file.")
     public Path inputPath;
 
     @CommandLine.Parameters(index = "1",
-            paramLabel = "path/to/output",
-            description = "Prefix for the output files")
-    public String outputPrefix;
+            paramLabel = "output",
+            description = "Prefix for the output files.")
+    public Path outputPrefix = Path.of("output");
 
     private static Function<VariantContext, Collection<VariantContext>> meltToSingleAltVariants() {
         return vc -> {
@@ -312,7 +312,7 @@ public class AnnotateVcfCommand extends AnnotatingSquirlsCommand {
                     .build();
 
             analysisResultsWriter.writeResults(results, prepareOutputOptions(outputPrefix));
-        } catch (SquirlsResourceException e) {
+        } catch (Exception e) {
             LOGGER.error("Error: ", e);
             return 1;
         }

--- a/squirls-cli/src/main/java/org/monarchinitiative/squirls/cli/writers/OutputOptions.java
+++ b/squirls-cli/src/main/java/org/monarchinitiative/squirls/cli/writers/OutputOptions.java
@@ -76,6 +76,7 @@
 
 package org.monarchinitiative.squirls.cli.writers;
 
+import java.nio.file.Path;
 import java.util.*;
 
 /**
@@ -87,7 +88,7 @@ public class OutputOptions {
     private final boolean reportFeatures;
     private final boolean reportAllTranscripts;
     private final Set<OutputFormat> outputFormats;
-    private final String outputPrefix;
+    private final Path outputPrefix;
 
     private OutputOptions(Builder builder) {
         this.compress = builder.compress;
@@ -117,7 +118,7 @@ public class OutputOptions {
         return outputFormats;
     }
 
-    public String outputPrefix() {
+    public Path outputPrefix() {
         return outputPrefix;
     }
 
@@ -151,7 +152,7 @@ public class OutputOptions {
         private boolean compress = false;
         private boolean reportFeatures = false;
         private boolean reportAllTranscripts = false;
-        private String outputPrefix = "output";
+        private Path outputPrefix = Path.of("output");
 
         private Builder() {
         }
@@ -171,7 +172,7 @@ public class OutputOptions {
             return this;
         }
 
-        public Builder setOutputPrefix(String outputPrefix) {
+        public Builder setOutputPrefix(Path outputPrefix) {
             this.outputPrefix = outputPrefix;
             return this;
         }

--- a/squirls-cli/src/main/java/org/monarchinitiative/squirls/cli/writers/ResultWriter.java
+++ b/squirls-cli/src/main/java/org/monarchinitiative/squirls/cli/writers/ResultWriter.java
@@ -80,6 +80,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.nio.file.Path;
 
 /**
  * Implementors write {@link AnalysisResults} in different formats.
@@ -89,5 +90,5 @@ public interface ResultWriter {
 
     Logger LOGGER = LoggerFactory.getLogger(ResultWriter.class);
 
-    void write(AnalysisResults results, String prefix) throws IOException;
+    void write(AnalysisResults results, Path prefix) throws IOException;
 }

--- a/squirls-cli/src/main/java/org/monarchinitiative/squirls/cli/writers/html/HtmlResultWriter.java
+++ b/squirls-cli/src/main/java/org/monarchinitiative/squirls/cli/writers/html/HtmlResultWriter.java
@@ -141,8 +141,8 @@ public class HtmlResultWriter implements ResultWriter {
     }
 
     @Override
-    public void write(AnalysisResults results, String prefix) throws IOException {
-        Path outputPath = Paths.get(prefix + '.' + OutputFormat.HTML.getFileExtension());
+    public void write(AnalysisResults results, Path prefix) throws IOException {
+        Path outputPath = Paths.get(prefix.toAbsolutePath().toString() + '.' + OutputFormat.HTML.getFileExtension());
         LOGGER.info("Writing HTML output to `{}`", outputPath);
 
         // sort results by max squirls pathogenicity and select at most n variants

--- a/squirls-cli/src/main/java/org/monarchinitiative/squirls/cli/writers/tabular/TabularResultWriter.java
+++ b/squirls-cli/src/main/java/org/monarchinitiative/squirls/cli/writers/tabular/TabularResultWriter.java
@@ -151,8 +151,8 @@ public class TabularResultWriter implements ResultWriter {
     }
 
     @Override
-    public void write(AnalysisResults results, String prefix) throws IOException {
-        String output = prefix + '.' + fileExtension + (compress ? ".gz" : "");
+    public void write(AnalysisResults results, Path prefix) throws IOException {
+        String output = prefix.toAbsolutePath().toString() + '.' + fileExtension + (compress ? ".gz" : "");
         Path outputPath = Paths.get(output);
         LOGGER.info("Writing tabular output to `{}`", outputPath);
 

--- a/squirls-cli/src/main/java/org/monarchinitiative/squirls/cli/writers/vcf/VcfResultWriter.java
+++ b/squirls-cli/src/main/java/org/monarchinitiative/squirls/cli/writers/vcf/VcfResultWriter.java
@@ -215,10 +215,10 @@ public class VcfResultWriter implements ResultWriter {
     }
 
     @Override
-    public void write(AnalysisResults results, String prefix) throws IOException {
+    public void write(AnalysisResults results, Path prefix) throws IOException {
         Path inputVcfPath = Paths.get(results.getSettingsData().getInputPath());
         String extension = compress ? OutputFormat.VCF.getFileExtension() + ".gz" : OutputFormat.VCF.getFileExtension();
-        Path outputPath = Paths.get(prefix + '.' + extension);
+        Path outputPath = Paths.get(prefix.toAbsolutePath().toString() + '.' + extension);
         LOGGER.info("Writing VCF output to `{}`", outputPath);
 
         VCFHeader header = prepareVcfHeader(inputVcfPath);

--- a/squirls-cli/src/test/java/org/monarchinitiative/squirls/cli/writers/html/HtmlResultWriterTest.java
+++ b/squirls-cli/src/test/java/org/monarchinitiative/squirls/cli/writers/html/HtmlResultWriterTest.java
@@ -160,6 +160,6 @@ public class HtmlResultWriterTest {
                         .build())
                 .addAllVariants(variantData)
                 .build();
-        resultWriter.write(results, OUTPATH.toString());
+        resultWriter.write(results, OUTPATH);
     }
 }

--- a/squirls-cli/src/test/java/org/monarchinitiative/squirls/cli/writers/tabular/TabularResultWriterTest.java
+++ b/squirls-cli/src/test/java/org/monarchinitiative/squirls/cli/writers/tabular/TabularResultWriterTest.java
@@ -148,7 +148,7 @@ public class TabularResultWriterTest {
                         .featureSource(FeatureSource.REFSEQ)
                         .build())
                 .build();
-        writer.write(results, OUTPUT.resolve("output").toString());
+        writer.write(results, OUTPUT.resolve("output"));
 
         // the file must exist
         Path expectedOutputFilePath = Paths.get("target/test-classes/tabular_output/output.tsv");
@@ -184,7 +184,7 @@ public class TabularResultWriterTest {
                         .featureSource(FeatureSource.REFSEQ)
                         .build())
                 .build();
-        writer.write(results, OUTPUT.resolve("output").toString());
+        writer.write(results, OUTPUT.resolve("output"));
 
         // the file must exist
         Path expectedOutputFilePath = Paths.get("target/test-classes/tabular_output/output.tsv.gz");
@@ -220,7 +220,7 @@ public class TabularResultWriterTest {
                         .featureSource(FeatureSource.REFSEQ)
                         .build())
                 .build();
-        writer.write(results, OUTPUT.resolve("output").toString());
+        writer.write(results, OUTPUT.resolve("output"));
 
         // the file must exist
         Path expectedOutputFilePath = Paths.get("target/test-classes/tabular_output/output.tsv");

--- a/squirls-cli/src/test/java/org/monarchinitiative/squirls/cli/writers/vcf/VcfResultWriterTest.java
+++ b/squirls-cli/src/test/java/org/monarchinitiative/squirls/cli/writers/vcf/VcfResultWriterTest.java
@@ -157,7 +157,7 @@ public class VcfResultWriterTest {
         Path output = OUTPUT.resolve("output");
 
         VcfResultWriter writer = new VcfResultWriter(true, true);
-        writer.write(results, output.toString());
+        writer.write(results, output);
 
         Path realOutputFile = Path.of(output + ".vcf.gz");
         assertThat(realOutputFile.toFile().isFile(), equalTo(true));
@@ -189,7 +189,7 @@ public class VcfResultWriterTest {
         Path output = OUTPUT.resolve("output");
 
         VcfResultWriter writer = new VcfResultWriter(false, true);
-        writer.write(results, output.toString());
+        writer.write(results, output);
 
         Path realOutputFile = Path.of(output + ".vcf");
         assertThat(realOutputFile.toFile().isFile(), equalTo(true));

--- a/squirls-ingest/src/main/java/org/monarchinitiative/squirls/ingest/IngestCommand.java
+++ b/squirls-ingest/src/main/java/org/monarchinitiative/squirls/ingest/IngestCommand.java
@@ -253,7 +253,7 @@ public class IngestCommand implements Callable<Integer> {
             }
 
         } catch (Exception e) {
-            LOGGER.error("Error: {}", e.getMessage());
+            LOGGER.error("Error: {}", e.getMessage(), e);
             return 1;
         }
         LOGGER.info("Done!");


### PR DESCRIPTION
Clarify meaning of the output CLI parameter, ensure non-existing parent directories are created, and store the result under `path/to/output/squirls*` prefix in case `path/to/output` points to an existing directory.

Fixes #37 