### PR TITLE
Support HGVS `g.` token in `annotate-pos` input

### DIFF
--- a/docs/running.rst
+++ b/docs/running.rst
@@ -47,6 +47,9 @@ The easiest way to quickly calculate Squirls scores for a couple of variants is 
   Do not forget to surround the variants with double quotes (``"chr9:136224694A>T"`` and *not* ``chr9:136224694A>T``)
   to prevent interpretation of the ``>`` as a shell operator.
 
+.. note::
+  Both ``"chr1:12345A>T"`` and ``"chr1:g.12345A>T"`` notations are supported.
+
 The command above generates the following terminal output::
 
   ...

--- a/squirls-cli/src/main/java/org/monarchinitiative/squirls/cli/cmd/annotate_pos/VariantChange.java
+++ b/squirls-cli/src/main/java/org/monarchinitiative/squirls/cli/cmd/annotate_pos/VariantChange.java
@@ -91,7 +91,7 @@ class VariantChange {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(VariantChange.class);
 
-    private static final Pattern VARIANT_PATTERN = Pattern.compile("(?<contig>(chr)?([\\d]{1,2}|X|Y|M])):(?<position>\\d+)(?<ref>[ACGTacgt]+)>(?<alt>[ACGTacgt]+)");
+    private static final Pattern VARIANT_PATTERN = Pattern.compile("(?<contig>(chr)?([\\d]{1,2}|X|Y|M])):(g\\.)?(?<position>\\d+)(?<ref>[ACGTacgt]+)>(?<alt>[ACGTacgt]+)");
     private final String contig;
     private final int pos;
     private final String ref, alt;

--- a/squirls-cli/src/test/java/org/monarchinitiative/squirls/cli/cmd/annotate_pos/VariantChangeTest.java
+++ b/squirls-cli/src/test/java/org/monarchinitiative/squirls/cli/cmd/annotate_pos/VariantChangeTest.java
@@ -76,7 +76,8 @@
 
 package org.monarchinitiative.squirls.cli.cmd.annotate_pos;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import java.util.Optional;
 
@@ -85,48 +86,25 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class VariantChangeTest {
 
-    @Test
-    void parseSnp() {
-        String payload = "chr1:123C>T";
-        final Optional<VariantChange> varchop = VariantChange.fromString(payload);
+    @ParameterizedTest
+    @CsvSource({
+            "         chr1:123C>T,        chr1,       123,   C,  T, chr1:123C>T",
+            "           Y:123C>CT,        chrY,       123,   C, CT, chrY:123C>CT",
+            "       chrX:123CCT>C,        chrX,       123, CCT,  C, chrX:123CCT>C",
+            "     chrX:g.123CCT>C,        chrX,       123, CCT,  C, chrX:123CCT>C",
+            "chr11:g.130473249G>A,       chr11, 130473249,   G,  A, chr11:130473249G>A"
+    })
+    public void parse(String payload, String contig, int pos, String ref, String alt, String variantChange) {
+        Optional<VariantChange> varchop = VariantChange.fromString(payload);
 
         assertThat(varchop.isPresent(), is(true));
-        final VariantChange ch = varchop.get();
+        VariantChange ch = varchop.get();
 
-        assertThat(ch.getContig(), is("chr1"));
-        assertThat(ch.getPos(), is(123));
-        assertThat(ch.getRef(), is("C"));
-        assertThat(ch.getAlt(), is("T"));
-        assertThat(ch.getVariantChange(), is("chr1:123C>T"));
+        assertThat(ch.getContig(), is(contig));
+        assertThat(ch.getPos(), is(pos));
+        assertThat(ch.getRef(), is(ref));
+        assertThat(ch.getAlt(), is(alt));
+        assertThat(ch.getVariantChange(), is(variantChange));
     }
 
-    @Test
-    void parseInsertion() {
-        String payload = "Y:123C>CT";
-        final Optional<VariantChange> varchop = VariantChange.fromString(payload);
-
-        assertThat(varchop.isPresent(), is(true));
-        final VariantChange ch = varchop.get();
-
-        assertThat(ch.getContig(), is("chrY"));
-        assertThat(ch.getPos(), is(123));
-        assertThat(ch.getRef(), is("C"));
-        assertThat(ch.getAlt(), is("CT"));
-        assertThat(ch.getVariantChange(), is("chrY:123C>CT"));
-    }
-
-    @Test
-    void parseDeletion() {
-        String payload = "chrX:123CCT>C";
-        final Optional<VariantChange> varchop = VariantChange.fromString(payload);
-
-        assertThat(varchop.isPresent(), is(true));
-        final VariantChange ch = varchop.get();
-
-        assertThat(ch.getContig(), is("chrX"));
-        assertThat(ch.getPos(), is(123));
-        assertThat(ch.getRef(), is("CCT"));
-        assertThat(ch.getAlt(), is("C"));
-        assertThat(ch.getVariantChange(), is("chrX:123CCT>C"));
-    }
 }


### PR DESCRIPTION
Both ``"chr1:12345A>T"`` and ``"chr1:g.12345A>T"`` notations are supported in `annotate-pos`