### PR TITLE
Externalize the project files required for building Squirls database.

### DIFF
--- a/squirls-ingest/README.md
+++ b/squirls-ingest/README.md
@@ -11,6 +11,8 @@ There are two commands that need to be run in order to build the resource files 
 
 ### Generate a config file
 
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.6395954.svg)](https://doi.org/10.5281/zenodo.6395954)
+
 We need to generate and fill the config file first. The config file requires paths/URLs to public resources 
 and the resources generated in Squirls project that are hosted on Zenodo.
 

--- a/squirls-ingest/README.md
+++ b/squirls-ingest/README.md
@@ -11,11 +11,11 @@ There are two commands that need to be run in order to build the resource files 
 
 ### Generate a config file
 
-We need to generate and fill the config file first. If you do not have some resources, download a resource bundle from
-[here](https://exomiser-threes.s3.amazonaws.com/threes-build-resources.zip).
+We need to generate and fill the config file first. The config file requires paths/URLs to public resources 
+and the resources generated in Squirls project that are hosted on Zenodo.
 
 ```bash
-java -jar squirls-ingest-1.0.4.jar generate-config config.yml
+java -jar squirls-ingest.jar generate-config config.yml
 ``` 
 
 Then, open the `config.yml` file and provide the required information.
@@ -25,7 +25,7 @@ Then, open the `config.yml` file and provide the required information.
 Having the config file ready, we can build the resource directory.
 
 ```bash
-java -jar squirls-ingest-1.0.4.jar ingest -c config.yml --assembly hg19 --db-version 2005 --build-dir path/to/build-dir 
+java -jar squirls-ingest.jar ingest -c config.yml --assembly hg19 --db-version 2005 --build-dir path/to/build-dir 
 ```
 
 where

--- a/squirls-ingest/src/main/java/org/monarchinitiative/squirls/ingest/IngestCommand.java
+++ b/squirls-ingest/src/main/java/org/monarchinitiative/squirls/ingest/IngestCommand.java
@@ -91,10 +91,10 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
@@ -192,6 +192,9 @@ public class IngestCommand implements Callable<Integer> {
             URL refseqUrl = new URL(ingestProperties.refseqUrl());
             URL ensemblUrl = new URL(ingestProperties.ensemblUrl());
             URL ucscUrl = new URL(ingestProperties.ucscUrl());
+            URL spliceMatrixUrl = new URL(ingestProperties.splicingInformationContentMatrix());
+            URL hexamerUrl = new URL(ingestProperties.hexamerTsvPath());
+            URL septamerUrl = new URL(ingestProperties.septamerTsvPath());
 
             String versionedAssembly = getVersionedAssembly(assembly, version);
             Path versionedAssemblyBuildPath = buildDirPath.resolve(versionedAssembly);
@@ -200,10 +203,16 @@ public class IngestCommand implements Callable<Integer> {
 
 
             // 2 - read classifier data
-            Map<SquirlsClassifierVersion, Path> classifiers = ingestProperties.classifiers().stream()
+            Map<SquirlsClassifierVersion, URL> classifiers = ingestProperties.classifiers().stream()
                     .collect(Collectors.toMap(
                             clfData -> SquirlsClassifierVersion.parseString(clfData.version()),
-                            clfData -> Paths.get(clfData.classifierPath())));
+                            clfData -> {
+                                try {
+                                    return new URL(clfData.classifierPath());
+                                } catch (MalformedURLException e) {
+                                    throw new RuntimeException(e);
+                                }
+                            }));
 
 
             // 3 - build database
@@ -211,9 +220,9 @@ public class IngestCommand implements Callable<Integer> {
                     genomeUrl, assemblyReportUrl,
                     refseqUrl, ensemblUrl, ucscUrl,
                     phylopUrl,
-                    Path.of(ingestProperties.splicingInformationContentMatrix()),
-                    Path.of(ingestProperties.hexamerTsvPath()),
-                    Path.of(ingestProperties.septamerTsvPath()),
+                    spliceMatrixUrl,
+                    hexamerUrl,
+                    septamerUrl,
                     classifiers);
 
 

--- a/squirls-ingest/src/main/resources/application-template.yml
+++ b/squirls-ingest/src/main/resources/application-template.yml
@@ -3,18 +3,24 @@
 ########################################################################################################################
 ### Zenodo resources
 #
-## path to YML file with definitions of splice sites
+## path to YML file with definitions of splice sites. Try this first:
+# https://zenodo.org/record/6395954/files/splicing-information-content-matrix.yaml?download=1
 splicingInformationContentMatrix:
 
-## path to TSV file with ESRSeq (hexamer) scores
+## path to TSV file with ESRSeq (hexamer) scores. Try this first:
+# https://zenodo.org/record/6395954/files/hexamer-scores.tsv?download=1
 hexamerTsvPath:
 
-## path to TSV file with SMS (septamer) scores
+## path to TSV file with SMS (septamer) scores. Try this first:
+# https://zenodo.org/record/6395954/files/septamer-scores.tsv?download=1
 septamerTsvPath:
 
 classifiers:
   # a list of classifiers to ingest
   # an unique version ID, e.g. `v1`
+  # Try these first:
+  #  https://zenodo.org/record/6395954/files/ensemble.lr.rf.v0.4.4.yaml?download=1
+  #  https://zenodo.org/record/6395954/files/ensemble.lr.rf.v0.4.6.yaml?download=1
   - version:
     # path to YML file with classifier data
     classifierPath:

--- a/squirls-ingest/src/test/java/org/monarchinitiative/squirls/ingest/FakeUpDatabase.java
+++ b/squirls-ingest/src/test/java/org/monarchinitiative/squirls/ingest/FakeUpDatabase.java
@@ -79,6 +79,7 @@ package org.monarchinitiative.squirls.ingest;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -94,10 +95,20 @@ public class FakeUpDatabase {
     private static final Path DATA_DIR = Paths.get("src/test/resources/org/monarchinitiative/squirls/ingest");
     private static final Path TX_DIR = DATA_DIR.resolve("transcripts");
 
-    private static final Path SPLICING_IC_MATRIX_PATH = DATA_DIR.resolve("parse").resolve("spliceSites.yaml");
+    private static final URL SPLICING_IC_MATRIX_PATH;
+    private static final URL HEXAMER_TSV_PATH;
+    private static final URL SEPTAMER_TSV_PATH;
+    static {
+        try {
+            SPLICING_IC_MATRIX_PATH = DATA_DIR.resolve("parse").resolve("spliceSites.yaml").toUri().toURL();
+            HEXAMER_TSV_PATH = DATA_DIR.resolve("hexamer-scores.tsv").toUri().toURL();
+            SEPTAMER_TSV_PATH = DATA_DIR.resolve("septamer-scores.tsv").toUri().toURL();
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
-    private static final Path HEXAMER_TSV_PATH = DATA_DIR.resolve("hexamer-scores.tsv");
-    private static final Path SEPTAMER_TSV_PATH = DATA_DIR.resolve("septamer-scores.tsv");
+
 
     @Test
     public void makeHg19Database() throws Exception {

--- a/squirls-ingest/src/test/java/org/monarchinitiative/squirls/ingest/SquirlsDataBuilderTest.java
+++ b/squirls-ingest/src/test/java/org/monarchinitiative/squirls/ingest/SquirlsDataBuilderTest.java
@@ -136,9 +136,9 @@ public class SquirlsDataBuilderTest {
         URL refseqUrl = hg19Dir.resolve("hg19_refseq_small.ser").toUri().toURL();
         URL ensemblUrl = hg19Dir.resolve("hg19_ensembl_small.ser").toUri().toURL();
         URL ucscUrl = hg19Dir.resolve("hg19_ucsc_small.ser").toUri().toURL();
-        Path yamlPath = DATA_DIR.resolve("parse").resolve("spliceSites.yaml");
-        Path hexamerPath = DATA_DIR.resolve("parse").resolve("hexamer-scores.tsv");
-        Path septamerPath = DATA_DIR.resolve("parse").resolve("septamer-scores.tsv");
+        URL yamlPath = DATA_DIR.resolve("parse").resolve("spliceSites.yaml").toUri().toURL();
+        URL hexamerPath = DATA_DIR.resolve("parse").resolve("hexamer-scores.tsv").toUri().toURL();
+        URL septamerPath = DATA_DIR.resolve("parse").resolve("septamer-scores.tsv").toUri().toURL();
 
         assertThat(Files.isRegularFile(buildDir.resolve("assembly_report.txt")), is(false));
         assertThat(Files.isRegularFile(buildDir.resolve("genome.fa")), is(false));

--- a/squirls-ingest/src/test/java/org/monarchinitiative/squirls/ingest/TestDataSourceConfig.java
+++ b/squirls-ingest/src/test/java/org/monarchinitiative/squirls/ingest/TestDataSourceConfig.java
@@ -85,6 +85,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 import javax.sql.DataSource;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
@@ -94,9 +96,17 @@ public class TestDataSourceConfig {
 
     public static final Path BASE_FOLDER = Path.of("src/test/resources/org/monarchinitiative/squirls/ingest");
 
-    public static final Map<SquirlsClassifierVersion, Path> MODEL_PATHS = Map.of(
-            SquirlsClassifierVersion.v0_4_4, Paths.get("src/test/resources/org/monarchinitiative/squirls/ingest/example_model.v0.4.4.yaml"),
-            SquirlsClassifierVersion.v0_4_6, Paths.get("src/test/resources/org/monarchinitiative/squirls/ingest/ensemble.lr.rf.v0.4.6.yaml"));
+    public static final Map<SquirlsClassifierVersion, URL> MODEL_PATHS = createModelUrls();
+
+    private static Map<SquirlsClassifierVersion, URL> createModelUrls() {
+        try {
+            return Map.of(
+                    SquirlsClassifierVersion.v0_4_4, Paths.get("src/test/resources/org/monarchinitiative/squirls/ingest/example_model.v0.4.4.yaml").toUri().toURL(),
+                    SquirlsClassifierVersion.v0_4_6, Paths.get("src/test/resources/org/monarchinitiative/squirls/ingest/ensemble.lr.rf.v0.4.6.yaml").toUri().toURL());
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
     @Bean
     public SplicingPwmData splicingPwmData() {


### PR DESCRIPTION
Squirls requires a bunch of project specific files for building the resource ZIP in `ingest`. Previously, these were provided as path to files on a local machine.

The project files were uploaded to [Zenodo](https://doi.org/10.5281/zenodo.6395954). Now, instead of paths, URLs pointing to location of the project files at Zenodo should be provided in the `ingest` configuration YAML file.

Now everybody can run `ingest` to build the Squirls resource files.