### PR TITLE
Add `--out-dir` option, rework prefix.

### DIFF
--- a/docs/running.rst
+++ b/docs/running.rst
@@ -65,6 +65,8 @@ Squirls reports scores in four columns:
 - maximum Squirls pathogenicity prediction rounded up to 3 significant digits
 - Squirls pathogenicity predictions calculated for each transcript the variant overlaps with
 
+.. note::
+  The options ``--output-format``, ``--n-variants-to-report``, ``--out-dir``, ``--report-features`` are ignored.
 
 ``annotate-csv`` - Annotate variant positions stored in a CSV file
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -74,9 +76,9 @@ To annotate more than just a few variant positions, it may be more convenient to
 Let's run the ``annotate-csv`` command to annotate four variants stored in the `example.csv`_ file
 (an example CSV file with 4 variants stored in Squirls repository)::
 
-  java -jar squirls-cli.jar annotate-csv -d $SQUIRLS_DATA example.csv path/to/output/file
+  java -jar squirls-cli.jar annotate-csv -d $SQUIRLS_DATA example.csv output
 
-Squirls reads the variants and stores the scores into ``path/to/output/file.html`` file. The *HTML* is the default output format,
+Squirls reads the variants and stores the scores into ``output.html`` file. The *HTML* is the default output format,
 see :ref:`rstoutputformats` section for more details.
 
 Mandatory arguments
@@ -100,6 +102,7 @@ In addition to the mandatory arguments, Squirls allows to fine tune the annotati
   in all output formats. Default: ``html``
 * ``-n, --n-variants-to-report`` - number of most pathogenic variants to include in *HTML* report. The option has
   no effect on *VCF* output format. Default: ``100``
+* ``--out-dir`` - path to folder where to write the output files. Default: current working directory
 * ``--report-features`` - include Squirls features into the output. Default: ``false``
 * ``-t | --transcript-source`` - transcript source to use. Choose one of ``{REFSEQ, ENSEMBL, UCSC}``. Default: ``REFSEQ``
 * ``--threads`` - process variants on *n* threads. Default: ``2``
@@ -137,6 +140,7 @@ In addition to the mandatory arguments, Squirls allows to fine tune the annotati
   in all output formats. Default: ``html``
 * ``-n, --n-variants-to-report`` - number of most pathogenic variants to include in *HTML* report. The option has
   no effect on *VCF* output format. Default: ``100``
+* ``--out-dir`` - path to folder where to write the output files. Default: current working directory
 * ``--report-features`` - include Squirls features into the output. Default: ``false``
 * ``-t | --transcript-source`` - transcript source to use. Choose one of ``{REFSEQ, ENSEMBL, UCSC}``. Default: ``REFSEQ``
 * ``--threads`` - process variants on *n* threads. Default: ``2``

--- a/squirls-cli/src/main/java/org/monarchinitiative/squirls/cli/cmd/annotate_csv/AnnotateCsvCommand.java
+++ b/squirls-cli/src/main/java/org/monarchinitiative/squirls/cli/cmd/annotate_csv/AnnotateCsvCommand.java
@@ -135,9 +135,8 @@ public class AnnotateCsvCommand extends AnnotatingSquirlsCommand {
     public Path inputPath;
 
     @CommandLine.Parameters(index = "1",
-            paramLabel = "output",
             description = "Prefix for the output files")
-    public Path outputPrefix = Path.of("output");
+    public String outputPrefix;
 
     private static GenomicVariant parseCsvRecord(GenomicAssembly assembly, CSVRecord record) throws SquirlsException {
         // parse contig

--- a/squirls-cli/src/main/java/org/monarchinitiative/squirls/cli/cmd/annotate_vcf/AnnotateVcfCommand.java
+++ b/squirls-cli/src/main/java/org/monarchinitiative/squirls/cli/cmd/annotate_vcf/AnnotateVcfCommand.java
@@ -97,7 +97,6 @@ import org.monarchinitiative.squirls.core.SquirlsDataService;
 import org.monarchinitiative.squirls.core.SquirlsResult;
 import org.monarchinitiative.squirls.core.VariantSplicingEvaluator;
 import org.monarchinitiative.squirls.core.reference.SplicingPwmData;
-import org.monarchinitiative.squirls.io.SquirlsResourceException;
 import org.monarchinitiative.svart.*;
 import org.monarchinitiative.svart.assembly.GenomicAssembly;
 import org.monarchinitiative.vmvt.core.VmvtGenerator;
@@ -134,9 +133,8 @@ public class AnnotateVcfCommand extends AnnotatingSquirlsCommand {
     public Path inputPath;
 
     @CommandLine.Parameters(index = "1",
-            paramLabel = "output",
             description = "Prefix for the output files.")
-    public Path outputPrefix = Path.of("output");
+    public String prefix;
 
     private static Function<VariantContext, Collection<VariantContext>> meltToSingleAltVariants() {
         return vc -> {
@@ -318,7 +316,7 @@ public class AnnotateVcfCommand extends AnnotatingSquirlsCommand {
                     .addAllVariants(annotated)
                     .build();
 
-            analysisResultsWriter.writeResults(results, prepareOutputOptions(outputPrefix));
+            analysisResultsWriter.writeResults(results, prepareOutputOptions(prefix));
         } catch (Exception e) {
             LOGGER.error("Error: ", e);
             return 1;

--- a/squirls-cli/src/main/java/org/monarchinitiative/squirls/cli/writers/AnalysisResultsWriterDefault.java
+++ b/squirls-cli/src/main/java/org/monarchinitiative/squirls/cli/writers/AnalysisResultsWriterDefault.java
@@ -104,7 +104,7 @@ public class AnalysisResultsWriterDefault implements AnalysisResultsWriter {
         for (OutputFormat format : options.outputFormats()) {
             ResultWriter writer = resultWriterForFormat(format, options.compress(), options.reportFeatures(), options.reportAllTranscripts());
             try {
-                writer.write(results, options.outputPrefix());
+                writer.write(results, options);
             } catch (IOException e) {
                 LOGGER.error("Error writing {} results: {}", format, e.getMessage());
             }

--- a/squirls-cli/src/main/java/org/monarchinitiative/squirls/cli/writers/OutputOptions.java
+++ b/squirls-cli/src/main/java/org/monarchinitiative/squirls/cli/writers/OutputOptions.java
@@ -88,14 +88,16 @@ public class OutputOptions {
     private final boolean reportFeatures;
     private final boolean reportAllTranscripts;
     private final Set<OutputFormat> outputFormats;
-    private final Path outputPrefix;
+    private final Path outputDirectory;
+    private final String prefix;
 
     private OutputOptions(Builder builder) {
         this.compress = builder.compress;
         this.reportFeatures = builder.reportFeatures;
         this.reportAllTranscripts = builder.reportAllTranscripts;
         this.outputFormats = Set.copyOf(builder.outputFormats);
-        this.outputPrefix = Objects.requireNonNull(builder.outputPrefix);
+        this.outputDirectory = Objects.requireNonNull(builder.outputDirectory);
+        this.prefix = Objects.requireNonNull(builder.prefix);
     }
 
     public static Builder builder() {
@@ -118,21 +120,12 @@ public class OutputOptions {
         return outputFormats;
     }
 
-    public Path outputPrefix() {
-        return outputPrefix;
+    public Path outputDirectory() {
+        return outputDirectory;
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        OutputOptions that = (OutputOptions) o;
-        return compress == that.compress && reportFeatures == that.reportFeatures && reportAllTranscripts == that.reportAllTranscripts && Objects.equals(outputFormats, that.outputFormats) && Objects.equals(outputPrefix, that.outputPrefix);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(compress, reportFeatures, reportAllTranscripts, outputFormats, outputPrefix);
+    public String prefix() {
+        return prefix;
     }
 
     @Override
@@ -142,7 +135,8 @@ public class OutputOptions {
                 ", reportFeatures=" + reportFeatures +
                 ", reportAllTranscripts=" + reportAllTranscripts +
                 ", outputFormats=" + outputFormats +
-                ", outputPrefix='" + outputPrefix + '\'' +
+                ", outputDirectory=" + outputDirectory +
+                ", prefix='" + prefix + '\'' +
                 '}';
     }
 
@@ -152,7 +146,8 @@ public class OutputOptions {
         private boolean compress = false;
         private boolean reportFeatures = false;
         private boolean reportAllTranscripts = false;
-        private Path outputPrefix = Path.of("output");
+        private Path outputDirectory;
+        private String prefix;
 
         private Builder() {
         }
@@ -172,8 +167,13 @@ public class OutputOptions {
             return this;
         }
 
-        public Builder setOutputPrefix(Path outputPrefix) {
-            this.outputPrefix = outputPrefix;
+        public Builder setOutputDirectory(Path outputDirectory) {
+            this.outputDirectory = outputDirectory;
+            return this;
+        }
+
+        public Builder setPrefix(String prefix) {
+            this.prefix = prefix;
             return this;
         }
 

--- a/squirls-cli/src/main/java/org/monarchinitiative/squirls/cli/writers/ResultWriter.java
+++ b/squirls-cli/src/main/java/org/monarchinitiative/squirls/cli/writers/ResultWriter.java
@@ -80,7 +80,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.nio.file.Path;
 
 /**
  * Implementors write {@link AnalysisResults} in different formats.
@@ -90,5 +89,5 @@ public interface ResultWriter {
 
     Logger LOGGER = LoggerFactory.getLogger(ResultWriter.class);
 
-    void write(AnalysisResults results, Path prefix) throws IOException;
+    void write(AnalysisResults results, OutputOptions outputOptions) throws IOException;
 }

--- a/squirls-cli/src/main/java/org/monarchinitiative/squirls/cli/writers/html/HtmlResultWriter.java
+++ b/squirls-cli/src/main/java/org/monarchinitiative/squirls/cli/writers/html/HtmlResultWriter.java
@@ -79,10 +79,7 @@ package org.monarchinitiative.squirls.cli.writers.html;
 import de.charite.compbio.jannovar.annotation.VariantAnnotations;
 import org.monarchinitiative.squirls.cli.visualization.SplicingVariantGraphicsGenerator;
 import org.monarchinitiative.squirls.cli.visualization.VisualizableVariantAllele;
-import org.monarchinitiative.squirls.cli.writers.AnalysisResults;
-import org.monarchinitiative.squirls.cli.writers.OutputFormat;
-import org.monarchinitiative.squirls.cli.writers.ResultWriter;
-import org.monarchinitiative.squirls.cli.writers.WritableSplicingAllele;
+import org.monarchinitiative.squirls.cli.writers.*;
 import org.monarchinitiative.squirls.core.SquirlsResult;
 import org.monarchinitiative.svart.CoordinateSystem;
 import org.monarchinitiative.svart.GenomicVariant;
@@ -95,7 +92,6 @@ import java.io.IOException;
 import java.io.Writer;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -141,8 +137,8 @@ public class HtmlResultWriter implements ResultWriter {
     }
 
     @Override
-    public void write(AnalysisResults results, Path prefix) throws IOException {
-        Path outputPath = Paths.get(prefix.toAbsolutePath().toString() + '.' + OutputFormat.HTML.getFileExtension());
+    public void write(AnalysisResults results, OutputOptions outputOptions) throws IOException {
+        Path outputPath = outputOptions.outputDirectory().resolve(outputOptions.prefix() + '.' + OutputFormat.HTML.getFileExtension());
         LOGGER.info("Writing HTML output to `{}`", outputPath);
 
         // sort results by max squirls pathogenicity and select at most n variants

--- a/squirls-cli/src/main/java/org/monarchinitiative/squirls/cli/writers/tabular/TabularResultWriter.java
+++ b/squirls-cli/src/main/java/org/monarchinitiative/squirls/cli/writers/tabular/TabularResultWriter.java
@@ -80,6 +80,7 @@ import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 import org.monarchinitiative.squirls.cli.writers.AnalysisResults;
+import org.monarchinitiative.squirls.cli.writers.OutputOptions;
 import org.monarchinitiative.squirls.cli.writers.ResultWriter;
 import org.monarchinitiative.squirls.cli.writers.WritableSplicingAllele;
 import org.monarchinitiative.squirls.core.SquirlsResult;
@@ -92,7 +93,6 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedList;
@@ -151,9 +151,8 @@ public class TabularResultWriter implements ResultWriter {
     }
 
     @Override
-    public void write(AnalysisResults results, Path prefix) throws IOException {
-        String output = prefix.toAbsolutePath().toString() + '.' + fileExtension + (compress ? ".gz" : "");
-        Path outputPath = Paths.get(output);
+    public void write(AnalysisResults results, OutputOptions outputOptions) throws IOException {
+        Path outputPath = outputOptions.outputDirectory().resolve(outputOptions.prefix() + '.' + fileExtension + (compress ? ".gz" : ""));
         LOGGER.info("Writing tabular output to `{}`", outputPath);
 
         List<String> header = new ArrayList<>(

--- a/squirls-cli/src/main/java/org/monarchinitiative/squirls/cli/writers/vcf/VcfResultWriter.java
+++ b/squirls-cli/src/main/java/org/monarchinitiative/squirls/cli/writers/vcf/VcfResultWriter.java
@@ -86,10 +86,7 @@ import htsjdk.variant.variantcontext.writer.Options;
 import htsjdk.variant.variantcontext.writer.VariantContextWriter;
 import htsjdk.variant.variantcontext.writer.VariantContextWriterBuilder;
 import htsjdk.variant.vcf.*;
-import org.monarchinitiative.squirls.cli.writers.AnalysisResults;
-import org.monarchinitiative.squirls.cli.writers.OutputFormat;
-import org.monarchinitiative.squirls.cli.writers.ResultWriter;
-import org.monarchinitiative.squirls.cli.writers.WritableSplicingAllele;
+import org.monarchinitiative.squirls.cli.writers.*;
 import org.monarchinitiative.squirls.core.SquirlsResult;
 import org.monarchinitiative.squirls.core.SquirlsTxResult;
 import org.monarchinitiative.svart.CoordinateSystem;
@@ -215,10 +212,10 @@ public class VcfResultWriter implements ResultWriter {
     }
 
     @Override
-    public void write(AnalysisResults results, Path prefix) throws IOException {
+    public void write(AnalysisResults results, OutputOptions outputOptions) throws IOException {
         Path inputVcfPath = Paths.get(results.getSettingsData().getInputPath());
         String extension = compress ? OutputFormat.VCF.getFileExtension() + ".gz" : OutputFormat.VCF.getFileExtension();
-        Path outputPath = Paths.get(prefix.toAbsolutePath().toString() + '.' + extension);
+        Path outputPath = outputOptions.outputDirectory().resolve(outputOptions.prefix() + '.' + extension);
         LOGGER.info("Writing VCF output to `{}`", outputPath);
 
         VCFHeader header = prepareVcfHeader(inputVcfPath);

--- a/squirls-cli/src/test/java/org/monarchinitiative/squirls/cli/writers/html/HtmlResultWriterTest.java
+++ b/squirls-cli/src/test/java/org/monarchinitiative/squirls/cli/writers/html/HtmlResultWriterTest.java
@@ -85,10 +85,7 @@ import org.junit.jupiter.api.Test;
 import org.monarchinitiative.squirls.cli.TestDataSourceConfig;
 import org.monarchinitiative.squirls.cli.data.VariantsForTesting;
 import org.monarchinitiative.squirls.cli.visualization.SplicingVariantGraphicsGenerator;
-import org.monarchinitiative.squirls.cli.writers.AnalysisResults;
-import org.monarchinitiative.squirls.cli.writers.AnalysisStats;
-import org.monarchinitiative.squirls.cli.writers.SettingsData;
-import org.monarchinitiative.squirls.cli.writers.WritableSplicingAllele;
+import org.monarchinitiative.squirls.cli.writers.*;
 import org.monarchinitiative.squirls.core.config.FeatureSource;
 import org.monarchinitiative.squirls.core.reference.SplicingPwmData;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -103,7 +100,7 @@ import java.util.Set;
 @SpringBootTest(classes = TestDataSourceConfig.class)
 public class HtmlResultWriterTest {
 
-    private static final Path OUTPATH = Paths.get("target/Sample192");
+    private static final Path OUTPATH = Paths.get("target");
 
     @Autowired
     public SplicingPwmData splicingPwmData;
@@ -160,6 +157,7 @@ public class HtmlResultWriterTest {
                         .build())
                 .addAllVariants(variantData)
                 .build();
-        resultWriter.write(results, OUTPATH);
+        OutputOptions outputOptions = OutputOptions.builder().setOutputDirectory(OUTPATH).setPrefix("Sample192").build();
+        resultWriter.write(results, outputOptions);
     }
 }

--- a/squirls-cli/src/test/java/org/monarchinitiative/squirls/cli/writers/tabular/TabularResultWriterTest.java
+++ b/squirls-cli/src/test/java/org/monarchinitiative/squirls/cli/writers/tabular/TabularResultWriterTest.java
@@ -82,10 +82,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.monarchinitiative.squirls.cli.TestDataSourceConfig;
 import org.monarchinitiative.squirls.cli.data.VariantsForTesting;
-import org.monarchinitiative.squirls.cli.writers.AnalysisResults;
-import org.monarchinitiative.squirls.cli.writers.AnalysisStats;
-import org.monarchinitiative.squirls.cli.writers.SettingsData;
-import org.monarchinitiative.squirls.cli.writers.WritableSplicingAllele;
+import org.monarchinitiative.squirls.cli.writers.*;
 import org.monarchinitiative.squirls.core.config.FeatureSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -148,7 +145,8 @@ public class TabularResultWriterTest {
                         .featureSource(FeatureSource.REFSEQ)
                         .build())
                 .build();
-        writer.write(results, OUTPUT.resolve("output"));
+        OutputOptions outputOptions = OutputOptions.builder().setOutputDirectory(OUTPUT).setPrefix("output").build();
+        writer.write(results, outputOptions);
 
         // the file must exist
         Path expectedOutputFilePath = Paths.get("target/test-classes/tabular_output/output.tsv");
@@ -184,7 +182,8 @@ public class TabularResultWriterTest {
                         .featureSource(FeatureSource.REFSEQ)
                         .build())
                 .build();
-        writer.write(results, OUTPUT.resolve("output"));
+        OutputOptions outputOptions = OutputOptions.builder().setOutputDirectory(OUTPUT).setPrefix("output").build();
+        writer.write(results, outputOptions);
 
         // the file must exist
         Path expectedOutputFilePath = Paths.get("target/test-classes/tabular_output/output.tsv.gz");
@@ -220,7 +219,8 @@ public class TabularResultWriterTest {
                         .featureSource(FeatureSource.REFSEQ)
                         .build())
                 .build();
-        writer.write(results, OUTPUT.resolve("output"));
+        OutputOptions outputOptions = OutputOptions.builder().setOutputDirectory(OUTPUT).setPrefix("output").build();
+        writer.write(results, outputOptions);
 
         // the file must exist
         Path expectedOutputFilePath = Paths.get("target/test-classes/tabular_output/output.tsv");

--- a/squirls-cli/src/test/java/org/monarchinitiative/squirls/cli/writers/vcf/VcfResultWriterTest.java
+++ b/squirls-cli/src/test/java/org/monarchinitiative/squirls/cli/writers/vcf/VcfResultWriterTest.java
@@ -88,10 +88,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.monarchinitiative.squirls.cli.TestDataSourceConfig;
 import org.monarchinitiative.squirls.cli.data.VariantsForTesting;
-import org.monarchinitiative.squirls.cli.writers.AnalysisResults;
-import org.monarchinitiative.squirls.cli.writers.AnalysisStats;
-import org.monarchinitiative.squirls.cli.writers.SettingsData;
-import org.monarchinitiative.squirls.cli.writers.WritableSplicingAllele;
+import org.monarchinitiative.squirls.cli.writers.*;
 import org.monarchinitiative.squirls.core.config.FeatureSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -154,12 +151,11 @@ public class VcfResultWriterTest {
                         .build())
                 .build();
 
-        Path output = OUTPUT.resolve("output");
-
         VcfResultWriter writer = new VcfResultWriter(true, true);
-        writer.write(results, output);
+        OutputOptions outputOptions = OutputOptions.builder().setOutputDirectory(OUTPUT).setPrefix("output").build();
+        writer.write(results, outputOptions);
 
-        Path realOutputFile = Path.of(output + ".vcf.gz");
+        Path realOutputFile = OUTPUT.resolve("output.vcf.gz");
         assertThat(realOutputFile.toFile().isFile(), equalTo(true));
 
         List<String> lines;
@@ -186,12 +182,11 @@ public class VcfResultWriterTest {
                         .build())
                 .build();
 
-        Path output = OUTPUT.resolve("output");
-
         VcfResultWriter writer = new VcfResultWriter(false, true);
-        writer.write(results, output);
+        OutputOptions outputOptions = OutputOptions.builder().setOutputDirectory(OUTPUT).setPrefix("output").build();
+        writer.write(results, outputOptions);
 
-        Path realOutputFile = Path.of(output + ".vcf");
+        Path realOutputFile = OUTPUT.resolve("output.vcf");
         assertThat(realOutputFile.toFile().isFile(), equalTo(true));
 
         List<String> lines;


### PR DESCRIPTION
Add `--out-dir` option into the CLI for providing path to the output directory. By default, store the results in the current working directory. Use the 2nd positional parameter only to get the prefix.